### PR TITLE
Add .startsWith polyfill

### DIFF
--- a/generators/python.js
+++ b/generators/python.js
@@ -1,4 +1,5 @@
 var util = require('../util');
+require('string.prototype.startswith');
 
 var toPython = function(curlCommand) {
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "cookie": "^0.1.2",
     "jsesc": "^0.5.0",
+    "string.prototype.startswith": "^0.2.0",
     "yargs": "NickCarneiro/yargs"
   },
   "devDependencies": {


### PR DESCRIPTION
The tests for node < 4 were failing, since there is no support for `startsWith`. I added a polyfill for it, but you could just change the build matrix too.