### PR TITLE
Fix single quotes issue with PHP

### DIFF
--- a/generators/php.js
+++ b/generators/php.js
@@ -1,7 +1,7 @@
 var util = require('../util');
 var querystring = require('querystring');
 
-var toPython = function(curlCommand) {
+var toPhp = function(curlCommand) {
 
     var request = util.parseCurlCommand(curlCommand);
 
@@ -32,7 +32,7 @@ var toPython = function(curlCommand) {
         var dataIndex = 0;
         for (var key in parsedQueryString) {
             var value = parsedQueryString[key];
-            dataString += "    '" + key + "' => '" + value + "'";
+            dataString += "    '" + key + "' => '" + value.replace(/[\\"']/g, '\\$&') + "'";
             if (dataIndex < dataCount - 1) {
                 dataString += ",\n";
             }
@@ -62,4 +62,4 @@ var toPython = function(curlCommand) {
 };
 
 
-module.exports = toPython;
+module.exports = toPhp;

--- a/test/curl18.txt
+++ b/test/curl18.txt
@@ -1,0 +1,1 @@
+curl google.com --data 'field=don%27t%20you%20like%20quotes'

--- a/test/php_output18.php
+++ b/test/php_output18.php
@@ -1,0 +1,7 @@
+<?php
+include('vendor/rmccue/requests/library/Requests.php');
+Requests::register_autoloader();
+$data = array(
+    'field' => 'don\'t you like quotes'
+);
+$response = Requests::post('google.com', $headers, $data);

--- a/test/test.js
+++ b/test/test.js
@@ -164,6 +164,14 @@ test('http post with data - php', function (t) {
   t.end();
 });
 
+test('http post with quotes inside data - php', function (t) {
+  var curlHttpPostCommand = fs.readFileSync(__dirname + '/curl18.txt', 'utf-8');
+  var phpCode = curlconverter.toPhp(curlHttpPostCommand);
+  var goodPhpCode = fs.readFileSync(__dirname + '/php_output18.php', 'utf-8').trim();
+  t.equal(phpCode, goodPhpCode);
+  t.end();
+});
+
 test('http get with single header - node', function (t) {
     var curlHttpPostCommand = fs.readFileSync(__dirname + '/curl8.txt', 'utf-8');
     var nodeCode = curlconverter.toNode(curlHttpPostCommand);


### PR DESCRIPTION
Aloha,
That for what I came for: strings with single quotes to the PHP converter is creating a wrong output.

Maybe we should discuss about how you're making your test cases, to make it easier to contribute. What if you change the output for one of the languages (obsolete library, new version with parameters change…)? I think you'll have to re-generate the output for each test, which will be a real and useless pain. It's nearly always the same process between each converters, so maybe by refactoring it into functions and testing theses functions directly… 

At least, having the same test files for all the languages would be great. 