### PR TITLE
tests: add curl post multiple times the same field

### DIFF
--- a/fixtures/curl_commands/post_same_field_multiple_times.txt
+++ b/fixtures/curl_commands/post_same_field_multiple_times.txt
@@ -1,0 +1,1 @@
+curl -X POST http://example.com/ --data 'foo=bar&foo=&foo=barbar'


### PR DESCRIPTION
I've seen that one of my requests (while writing the julia port) failed because of multiple post data with the same key.
Here's an example:
    http://stackoverflow.com/questions/7880619/multiple-inputs-with-same-name-through-post-in-php

And how this is done in python:
    http://stackoverflow.com/questions/23384230/how-to-post-multiple-value-with-same-key-in-python-requests

I've tried the python converter and it does not manage it correctly, so some tests might be needed