### PR TITLE
Add CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,13 @@ response = requests.get('http://en.wikipedia.org/', headers=headers, cookies=coo
 ## Contributing
 
 > I'd rather write programs to write programs than write programs.
-> 
-> 
+>
+>
 > Dick Sites, Digital Equipment Corporation, September 1985
 
 Make sure you're running node 6 or greater. The test suite will fail on older versions of node.
+
+If you add a new generator, make sure to update the list of supported languages in [cli.js](bin/cli.js) or else it won't be accessible from the command line
 
 If you want to add new functionality, start with a test.
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+const curlconverter = require('../index.js')
+const argv = require('yargs').argv
+const fs = require('fs')
+
+// se a default incase -l/--langauge isn't passed
+const defaultLanguage = 'python'
+
+// used to map languages to functions
+// NOTE: make sure to update this when adding langauge support
+const translate = {
+  r: 'toR',
+  php: 'toPhp',
+  python: 'toPython',
+  node: 'toNode',
+  go: 'toGo',
+  strest: 'toStrest',
+  rust: 'toRust',
+  json: 'toJsonString'
+}
+
+// outputs the help menu
+function help() {
+  console.log(`usage: curlconverter [-l <language>] [<curl>]
+
+options:
+\t-l, --language\t the language to convert the curl command to
+
+stdin:
+\tif no <curl> is passes, the script will read from stdin
+
+languages:
+\t${ Object.keys(translate).join('\n\t') }`);
+}
+
+(async () => {
+  if (argv.h || argv.help)
+    return help()
+
+  const language = argv.l || argv.language
+
+  // used either the language passed of the default
+  const fnName = language ? translate[language] : translate[defaultLanguage]
+
+  // if true, the used passed in an unsuppored langauge
+  if (!fnName)
+    return console.error('error: language not supported'), help()
+
+  // either use the unnamed argument or read from stdin
+  const curl = argv._.length ? argv._[0] : fs.readFileSync(0, 'utf8')
+  const generator = curlconverter[fnName]
+  const code = generator(curl)
+  console.log(code)
+})()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "curlconverter",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -792,12 +792,6 @@
       "requires": {
         "is-property": "^1.0.0"
       }
-    },
-    "get-stdin": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
-      "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
-      "dev": true
     },
     "glob": {
       "version": "7.1.2",
@@ -1605,6 +1599,14 @@
         "get-stdin": "^5.0.1",
         "minimist": "^1.1.0",
         "pkg-conf": "^2.0.0"
+      },
+      "dependencies": {
+        "get-stdin": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+          "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
+          "dev": true
+        }
       }
     },
     "string-width": {

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
   "dependencies": {
     "cmd": "^0.1.0",
     "cookie": "^0.1.2",
-    "yamljs": "^0.3.0",
     "jsesc": "^0.5.0",
     "string.prototype.startswith": "^0.2.0",
+    "yamljs": "^0.3.0",
     "yargs": "NickCarneiro/yargs"
   },
   "devDependencies": {
@@ -31,5 +31,8 @@
   },
   "scripts": {
     "test": "./test.sh"
+  },
+  "bin": {
+    "curlconverter": "bin/cli.js"
   }
 }


### PR DESCRIPTION
# CIL Support

Added the ability to utilize these functions from the command line.

I took the library to set the default language to `python` but feel free to update it as you see fit.

I also wasn't sure about how you wanted to increment the version number so I will leave that up to you.

Additionally, I wasn't sure how you would like to test this addition so I'll also leave that up to you. I did some minor testing and being such a simple script I think it will do just fine out in the wild.

First:
`npm i curlconverter -g`
Then:
```bash
curlconverter --language node 'wget --header="Cookie: testing=working" https://httpbin.org/cookies'
```
```js
var request = require('request');

var headers = {
    'Cookie': 'testing=working'
};

var options = {
    url: 'https://httpbin.org/cookies',
    headers: headers
};

function callback(error, response, body) {
    if (!error && response.statusCode == 200) {
        console.log(body);
    }
}

request(options, callback);

```
Or:
```bash
echo 'wget --header="Cookie: testing=working" https://httpbin.org/cookies' | curlconverter
```
```py
import requests

cookies = {
    'testing': 'working',
}

headers = {
}

response = requests.get('https://httpbin.org/cookies', headers=headers, cookies=cookies)

```
Lastly:
Thank you for building such a helpful tool!