### PR TITLE
Add -G data conversion to QueryString, support for HEAD, fix Dart

### DIFF
--- a/fixtures/curl_commands/get_with_data.txt
+++ b/fixtures/curl_commands/get_with_data.txt
@@ -1,0 +1,1 @@
+curl -v -H 'X-Api-Key:123456789' https://synthetics.newrelic.com/synthetics/api/v3/monitors?test=2 -G -d 'limit=100' -d 'w=4'

--- a/fixtures/curl_commands/get_with_data2.txt
+++ b/fixtures/curl_commands/get_with_data2.txt
@@ -1,0 +1,4 @@
+curl -X PUT 'https://api.newrelic.com/v2/alerts_policy_channels.json' \
+     -H 'X-Api-Key:{admin_api_key}' -i \
+     -H 'Content-Type: application/json' \
+     -G -d 'policy_id=policy_id&channel_ids=channel_id'

--- a/fixtures/curl_commands/head.txt
+++ b/fixtures/curl_commands/head.txt
@@ -1,0 +1,1 @@
+curl --head http://www.url.com/page

--- a/fixtures/curl_commands/head_with_I_option.txt
+++ b/fixtures/curl_commands/head_with_I_option.txt
@@ -1,0 +1,1 @@
+curl -I http://www.url.com/page

--- a/fixtures/curl_commands/put_with_T_option.txt
+++ b/fixtures/curl_commands/put_with_T_option.txt
@@ -1,0 +1,8 @@
+curl 'http://localhost:9200/twitter/_mapping/user?pretty' -H 'Content-Type: application/json' -T -d '\
+{\
+"properties": {\
+"email": {\
+"type": "keyword"\
+}\
+}\
+}'

--- a/fixtures/dart_output/get_basic_auth.dart
+++ b/fixtures/dart_output/get_basic_auth.dart
@@ -6,7 +6,7 @@ void main() async {
   var pword = 'some_password';
   var authn = 'Basic ' + base64Encode(utf8.encode('$uname:$pword'));
 
-  var res = await http.get('https://api.test.com/', headers: {'authorization': authn});
+  var res = await http.get('https://api.test.com/', headers: {'Authorization': authn});
   if (res.statusCode != 200) throw Exception('get error: statusCode= ${res.statusCode}');
   print(res.body);
 }

--- a/fixtures/dart_output/get_basic_auth_no_user.dart
+++ b/fixtures/dart_output/get_basic_auth_no_user.dart
@@ -6,7 +6,7 @@ void main() async {
   var pword = 'some_password';
   var authn = 'Basic ' + base64Encode(utf8.encode('$uname:$pword'));
 
-  var res = await http.get('https://api.test.com/', headers: {'authorization': authn});
+  var res = await http.get('https://api.test.com/', headers: {'Authorization': authn});
   if (res.statusCode != 200) throw Exception('get error: statusCode= ${res.statusCode}');
   print(res.body);
 }

--- a/fixtures/dart_output/get_charles_syntax.dart
+++ b/fixtures/dart_output/get_charles_syntax.dart
@@ -6,7 +6,7 @@ void main() async {
     'Accept': '*/*',
     'User-Agent': 'GiftTalk/2.7.2 (iPhone; iOS 9.0.2; Scale/3.00)',
     'Accept-Language': 'en-CN;q=1, zh-Hans-CN;q=0.9',
-    'accept-encoding': 'gzip',
+    'Accept-Encoding': 'gzip',
   };
 
   var res = await http.get('http://api.ipify.org/?format=json&', headers: headers);

--- a/fixtures/dart_output/get_with_browser_headers.dart
+++ b/fixtures/dart_output/get_with_browser_headers.dart
@@ -9,7 +9,7 @@ void main() async {
     'Referer': 'http://www.wikipedia.org/',
     'Connection': 'keep-alive',
     'Cookie': 'GeoIP=US:Albuquerque:35.1241:-106.7675:v4; uls-previous-languages=%5B%22en%22%5D; mediaWiki.user.sessionId=VaHaeVW3m0ymvx9kacwshZIDkv8zgF9y; centralnotice_buckets_by_campaign=%7B%22C14_enUS_dsk_lw_FR%22%3A%7B%22val%22%3A%220%22%2C%22start%22%3A1412172000%2C%22end%22%3A1422576000%7D%2C%22C14_en5C_dec_dsk_FR%22%3A%7B%22val%22%3A3%2C%22start%22%3A1417514400%2C%22end%22%3A1425290400%7D%2C%22C14_en5C_bkup_dsk_FR%22%3A%7B%22val%22%3A1%2C%22start%22%3A1417428000%2C%22end%22%3A1425290400%7D%7D; centralnotice_bannercount_fr12=22; centralnotice_bannercount_fr12-wait=14',
-    'accept-encoding': 'gzip',
+    'Accept-Encoding': 'gzip',
   };
 
   var res = await http.get('http://en.wikipedia.org/', headers: headers);

--- a/fixtures/dart_output/post_with_browser_headers.dart
+++ b/fixtures/dart_output/post_with_browser_headers.dart
@@ -11,7 +11,7 @@ void main() async {
     'Connection': 'keep-alive',
     'Content-Length': '0',
     'Cookie': '_gat=1; ASPSESSIONIDACCRDTDC=MCMDKFMBLLLHGKCGNMKNGPKI; _ga=GA1.2.1424920226.1419478126',
-    'accept-encoding': 'gzip',
+    'Accept-Encoding': 'gzip',
   };
 
   var res = await http.post('http://www.w3schools.com/ajax/demo_post.asp', headers: headers);

--- a/fixtures/dart_output/post_with_data_binary.dart
+++ b/fixtures/dart_output/post_with_data_binary.dart
@@ -3,7 +3,7 @@ import 'package:http/http.dart' as http;
 
 void main() async {
   var headers = {
-    'content-type': 'application/x-www-form-urlencoded',
+    'Content-Type': 'application/x-www-form-urlencoded',
   };
 
   var data = utf8.encode('{"title":"china1"}');

--- a/fixtures/dart_output/post_with_urlencoded_data.dart
+++ b/fixtures/dart_output/post_with_urlencoded_data.dart
@@ -11,7 +11,7 @@ void main() async {
     'Referer': 'http://fiddle.jshell.net/_display/',
     'X-Requested-With': 'XMLHttpRequest',
     'Connection': 'keep-alive',
-    'accept-encoding': 'gzip',
+    'Accept-Encoding': 'gzip',
   };
 
   var data = 'msg1=wow&msg2=such';

--- a/fixtures/dart_output/put_basic_auth_json_data.dart
+++ b/fixtures/dart_output/put_basic_auth_json_data.dart
@@ -7,8 +7,8 @@ void main() async {
   var authn = 'Basic ' + base64Encode(utf8.encode('$uname:$pword'));
 
   var headers = {
-    'authorization': authn,
-    'content-type': 'application/x-www-form-urlencoded',
+    'Authorization': authn,
+    'Content-Type': 'application/x-www-form-urlencoded',
   };
 
   var data = '{"admins":{"names":[], "roles":[]}, "readers":{"names":["joe"],"roles":[]}}';

--- a/fixtures/dart_output/put_xput.dart
+++ b/fixtures/dart_output/put_xput.dart
@@ -1,0 +1,13 @@
+import 'package:http/http.dart' as http;
+
+void main() async {
+  var headers = {
+    'Content-Type': 'application/json',
+  };
+
+  var data = '{"properties": {"email": {"type": "keyword"}}}';
+
+  var res = await http.put('http://localhost:9200/twitter/_mapping/user?pretty', headers: headers, body: data);
+  if (res.statusCode != 200) throw Exception('put error: statusCode= ${res.statusCode}');
+  print(res.body);
+}

--- a/fixtures/python_output/get_with_data.py
+++ b/fixtures/python_output/get_with_data.py
@@ -1,0 +1,18 @@
+import requests
+
+headers = {
+    'X-Api-Key': '123456789',
+}
+
+params = (
+    ('test', '2'),
+    ('limit', '100'),
+    ('w', '4'),
+)
+
+response = requests.get('https://synthetics.newrelic.com/synthetics/api/v3/monitors', headers=headers, params=params)
+
+#NB. Original query string below. It seems impossible to parse and
+#reproduce query strings 100% accurately so the one below is given
+#in case the reproduced version is not "correct".
+# response = requests.get('https://synthetics.newrelic.com/synthetics/api/v3/monitors?test=2&limit=100&w=4', headers=headers)

--- a/fixtures/python_output/get_with_data2.py
+++ b/fixtures/python_output/get_with_data2.py
@@ -1,0 +1,18 @@
+import requests
+
+headers = {
+    'X-Api-Key': '{admin_api_key}',
+    'Content-Type': 'application/json',
+}
+
+params = (
+    ('policy_id', 'policy_id'),
+    ('channel_ids', 'channel_id'),
+)
+
+response = requests.put('https://api.newrelic.com/v2/alerts_policy_channels.json', headers=headers, params=params)
+
+#NB. Original query string below. It seems impossible to parse and
+#reproduce query strings 100% accurately so the one below is given
+#in case the reproduced version is not "correct".
+# response = requests.put('https://api.newrelic.com/v2/alerts_policy_channels.json?policy_id=policy_id&channel_ids=channel_id', headers=headers)

--- a/fixtures/python_output/head.py
+++ b/fixtures/python_output/head.py
@@ -1,0 +1,3 @@
+import requests
+
+response = requests.head('http://www.url.com/page')

--- a/fixtures/python_output/head_with_I_option.py
+++ b/fixtures/python_output/head_with_I_option.py
@@ -1,0 +1,3 @@
+import requests
+
+response = requests.head('http://www.url.com/page')

--- a/fixtures/python_output/put_with_T_option.py
+++ b/fixtures/python_output/put_with_T_option.py
@@ -1,0 +1,18 @@
+import requests
+
+headers = {
+    'Content-Type': 'application/json',
+}
+
+params = (
+    ('pretty', ''),
+)
+
+data = '{"properties": {"email": {"type": "keyword"}}}'
+
+response = requests.put('http://localhost:9200/twitter/_mapping/user', headers=headers, params=params, data=data)
+
+#NB. Original query string below. It seems impossible to parse and
+#reproduce query strings 100% accurately so the one below is given
+#in case the reproduced version is not "correct".
+# response = requests.put('http://localhost:9200/twitter/_mapping/user?pretty', headers=headers, data=data)

--- a/fixtures/rust_output/head.rs
+++ b/fixtures/rust_output/head.rs
@@ -1,0 +1,12 @@
+extern crate reqwest;
+
+fn main() -> Result<(), reqwest::Error> {
+
+    let res = reqwest::Client::new()
+        .head("http://www.url.com/page")
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}

--- a/generators/dart.js
+++ b/generators/dart.js
@@ -34,9 +34,11 @@ var toDart = function (curlCommand) {
       s += "    'Cookie': '" + cookiestr + "',\n"
     }
 
-    if (r.auth) s += "    'authorization': authn,\n"
-    if (r.compressed) s += "    'accept-encoding': 'gzip',\n"
-    if (r.isDataBinary || r.method === 'put') s += "    'content-type': 'application/x-www-form-urlencoded',\n"
+    if (r.auth) s += "    'Authorization': authn,\n"
+    if (r.compressed) s += "    'Accept-Encoding': 'gzip',\n"
+    if (!hasHeaders['Content-Type'] && (r.isDataBinary || r.method === 'put')) {
+      s += "    'Content-Type': 'application/x-www-form-urlencoded',\n"
+    }
 
     s += '  };\n'
     s += '\n'
@@ -67,7 +69,7 @@ var toDart = function (curlCommand) {
 
   s += '  var res = await http.' + r.method + "('" + r.url + "'"
   if (hasHeaders) s += ', headers: headers'
-  else if (r.auth) s += ", headers: {'authorization': authn}"
+  else if (r.auth) s += ", headers: {'Authorization': authn}"
   if (hasData) s += ', body: data'
 
   /* eslint-disable no-template-curly-in-string */

--- a/generators/rust.js
+++ b/generators/rust.js
@@ -50,6 +50,9 @@ var toRust = function (curlCommand) {
     case 'put':
       rustCode += '        .put("' + request.url + '")'
       break
+    case 'head':
+      rustCode += '        .head("' + request.url + '")'
+      break
     case 'patch':
       rustCode += '        .patch("' + request.url + '")'
       break


### PR DESCRIPTION
# Proposed changes
## `-G` / `--get` support for data conversion to Query String
> When used, this option will make all data specified with -d, --data, --data-binary or  --data-urlencode  to  be used in an HTTP GET request instead of the POST request that otherwise would be used. The data will be appended to the URL with a '?' separator.

Currently with `curlconverter` the request is incorrectly read as `POST` instead of `GET`, and there are some discussions on StackOverflow regarding this issue:
* https://stackoverflow.com/questions/56993838/converting-a-curl-x-put-g-to-python-using-the-requests-module
* https://stackoverflow.com/questions/57498984/converting-curl-to-python-http-415-unsupported-media-type

I have modified `util.js` to add this option.

Similarly `-T` / `--upload-file` option uses HTTP PUT. My code is also checks for `-T` option.

## `HEAD` request support
cURL has an option `-I` / `--head` which fetches only headers.

I have added it to Rust generator (as others already had it), and also added Python + Rust tests.

## Dart sends only one `Content-Type` request
* Added a test `put_xput.dart` test, where I found that generator was adding duplicate content type.
* If the request already has a `Content-Type`, then avoid adding `application/x-www-form-urlencoded` additional Content-Type (thus fix the above issue).