### PR TITLE
Fix quoting issues in Rust and PHP generators

### DIFF
--- a/fixtures/curl_commands/post_with_quotes_anywhere.txt
+++ b/fixtures/curl_commands/post_with_quotes_anywhere.txt
@@ -1,0 +1,6 @@
+curl 'https://example.com' \
+    -d "a=b&c=\"&d='" \
+    -u "ol':asd\"" \
+    -H "A: ''a'" \
+    -H 'B: "' \
+    -H "Cookie: x=1'; y=2\""

--- a/fixtures/php_output/post_with_quotes_anywhere.php
+++ b/fixtures/php_output/post_with_quotes_anywhere.php
@@ -1,0 +1,15 @@
+<?php
+include('vendor/rmccue/requests/library/Requests.php');
+Requests::register_autoloader();
+$headers = array(
+    'A' => '\'\'a\'',
+    'B' => '"',
+    'Cookie' => 'x=1\'; y=2"'
+);
+$data = array(
+    'a' => 'b',
+    'c' => '"',
+    'd' => '\''
+);
+$options = array('auth' => array('ol\'', 'asd"'));
+$response = Requests::post('https://example.com', $headers, $data, $options);

--- a/fixtures/rust_output/get_with_form.rs
+++ b/fixtures/rust_output/get_with_form.rs
@@ -9,7 +9,7 @@ fn main() -> Result<(), reqwest::Error> {
         .text("text", "Testing the converter!");
 
     let res = reqwest::Client::new()
-        .post("\")
+        .post("\\")
         .basic_auth("test", Some(""))
         .multipart(form)
         .send()?

--- a/fixtures/rust_output/post_with_quotes_anywhere.rs
+++ b/fixtures/rust_output/post_with_quotes_anywhere.rs
@@ -1,0 +1,21 @@
+extern crate reqwest;
+use reqwest::headers::*;
+
+fn main() -> Result<(), reqwest::Error> {
+    let mut headers = HeaderMap::new();
+    headers.insert(A, "''a'".parse().unwrap());
+    headers.insert(B, "\"".parse().unwrap());
+    headers.insert(COOKIE, "x".parse().unwrap());
+    headers.insert(COOKIE, "y".parse().unwrap());
+
+    let res = reqwest::Client::new()
+        .post("https://example.com")
+        .basic_auth("ol'", Some("asd\""))
+        .headers(headers)
+        .body("a=b&c=\"&d='")
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}

--- a/generators/php.js
+++ b/generators/php.js
@@ -1,5 +1,8 @@
 var util = require('../util')
 var querystring = require('querystring')
+const jsesc = require('jsesc')
+
+const quote = str => jsesc(str, { quotes: 'single' })
 
 var toPhp = function (curlCommand) {
   var request = util.parseCurlCommand(curlCommand)
@@ -10,14 +13,14 @@ var toPhp = function (curlCommand) {
     var i = 0
     var headerCount = Object.keys(request.headers).length
     for (var headerName in request.headers) {
-      headerString += "    '" + headerName + "' => '" + request.headers[headerName] + "'"
+      headerString += "    '" + headerName + "' => '" + quote(request.headers[headerName]) + "'"
       if (i < headerCount - 1) {
         headerString += ',\n'
       }
       i++
     }
     if (request.cookies) {
-      var cookieString = util.serializeCookies(request.cookies)
+      var cookieString = quote(util.serializeCookies(request.cookies))
       headerString += ",\n    'Cookie' => '" + cookieString + "'"
     }
     headerString += '\n);'
@@ -27,7 +30,7 @@ var toPhp = function (curlCommand) {
 
   var optionsString = false
   if (request.auth) {
-    var splitAuth = request.auth.split(':')
+    var splitAuth = request.auth.split(':').map(quote)
     var user = splitAuth[0] || ''
     var password = splitAuth[1] || ''
     optionsString = "$options = array('auth' => array('" + user + "', '" + password + "'));"
@@ -42,12 +45,12 @@ var toPhp = function (curlCommand) {
     dataString = '$data = array(\n'
     var dataCount = Object.keys(parsedQueryString).length
     if (dataCount === 1 && !parsedQueryString[Object.keys(parsedQueryString)[0]]) {
-      dataString = "$data = '" + request.data + "';"
+      dataString = "$data = '" + quote(request.data) + "';"
     } else {
       var dataIndex = 0
       for (var key in parsedQueryString) {
         var value = parsedQueryString[key]
-        dataString += "    '" + key + "' => '" + value.replace(/[\\"']/g, '\\$&') + "'"
+        dataString += "    '" + key + "' => '" + quote(value) + "'"
         if (dataIndex < dataCount - 1) {
           dataString += ',\n'
         }


### PR DESCRIPTION
This ensures that single or double quotes are properly escaped in Rust and PHP generators.

It also adds some test cases to ensure correct behavior. Note that an additional test (`get_with_form`) was changed but is incorrect, and will be fixed once #170 is merged. 