### PR TITLE
Rust generator refactor

### DIFF
--- a/fixtures/curl_commands/multipart_with_headers.txt
+++ b/fixtures/curl_commands/multipart_with_headers.txt
@@ -1,0 +1,6 @@
+curl https://upload.box.com/api/2.0/files/content \
+    -H "Authorization: Bearer ACCESS_TOKEN" \
+    -X POST \
+    -H 'X-Nice: Header' \
+    -F attributes='{"name":"tigers.jpeg", "parent":{"id":"11446498"}}' \
+    -F file=@myfile.jpg

--- a/fixtures/curl_commands/post_with_quotes_anywhere.txt
+++ b/fixtures/curl_commands/post_with_quotes_anywhere.txt
@@ -1,0 +1,6 @@
+curl 'https://example.com' \
+    -d "a=b&c=\"&d='" \
+    -u "ol':asd\"" \
+    -H "A: ''a'" \
+    -H 'B: "' \
+    -H "Cookie: x=1'; y=2\""

--- a/fixtures/php_output/post_with_quotes_anywhere.php
+++ b/fixtures/php_output/post_with_quotes_anywhere.php
@@ -1,0 +1,15 @@
+<?php
+include('vendor/rmccue/requests/library/Requests.php');
+Requests::register_autoloader();
+$headers = array(
+    'A' => '\'\'a\'',
+    'B' => '"',
+    'Cookie' => 'x=1\'; y=2"'
+);
+$data = array(
+    'a' => 'b',
+    'c' => '"',
+    'd' => '\''
+);
+$options = array('auth' => array('ol\'', 'asd"'));
+$response = Requests::post('https://example.com', $headers, $data, $options);

--- a/fixtures/rust_output/delete.rs
+++ b/fixtures/rust_output/delete.rs
@@ -1,7 +1,6 @@
 extern crate reqwest;
 
-fn main() -> Result<(), reqwest::Error> {
-
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let res = reqwest::Client::new()
         .delete("http://www.url.com/page")
         .send()?

--- a/fixtures/rust_output/get_basic_auth.rs
+++ b/fixtures/rust_output/get_basic_auth.rs
@@ -1,7 +1,6 @@
 extern crate reqwest;
 
-fn main() -> Result<(), reqwest::Error> {
-
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let res = reqwest::Client::new()
         .get("https://api.test.com/")
         .basic_auth("some_username", Some("some_password"))

--- a/fixtures/rust_output/get_basic_auth_no_user.rs
+++ b/fixtures/rust_output/get_basic_auth_no_user.rs
@@ -1,7 +1,6 @@
 extern crate reqwest;
 
-fn main() -> Result<(), reqwest::Error> {
-
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let res = reqwest::Client::new()
         .get("https://api.test.com/")
         .basic_auth("", Some("some_password"))

--- a/fixtures/rust_output/get_user_agent.rs
+++ b/fixtures/rust_output/get_user_agent.rs
@@ -1,10 +1,10 @@
 extern crate reqwest;
-use reqwest::headers::*;
+use reqwest::header;
 
-fn main() -> Result<(), reqwest::Error> {
-    let mut headers = HeaderMap::new();
-    headers.insert(X_MSISDN, "XXXXXXXXXXXXX".parse().unwrap());
-    headers.insert(USER_AGENT, "Mozilla Android6.1".parse().unwrap());
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("x-msisdn", "XXXXXXXXXXXXX".parse().unwrap());
+    headers.insert("User-Agent", "Mozilla Android6.1".parse().unwrap());
 
     let res = reqwest::Client::new()
         .get("http://205.147.98.6/vc/moviesmagic?p=5&pub=testmovie&tkn=817263812")

--- a/fixtures/rust_output/get_with_form.rs
+++ b/fixtures/rust_output/get_with_form.rs
@@ -1,7 +1,7 @@
 extern crate reqwest;
 use reqwest::multipart;
 
-fn main() -> Result<(), reqwest::Error> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let form = multipart::Form::new()
         .text("from", "test@tester.com")
         .text("to", "devs@tester.net")

--- a/fixtures/rust_output/get_with_form.rs
+++ b/fixtures/rust_output/get_with_form.rs
@@ -9,7 +9,7 @@ fn main() -> Result<(), reqwest::Error> {
         .text("text", "Testing the converter!");
 
     let res = reqwest::Client::new()
-        .post("\")
+        .post("\\")
         .basic_auth("test", Some(""))
         .multipart(form)
         .send()?

--- a/fixtures/rust_output/head.rs
+++ b/fixtures/rust_output/head.rs
@@ -1,7 +1,6 @@
 extern crate reqwest;
 
-fn main() -> Result<(), reqwest::Error> {
-
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let res = reqwest::Client::new()
         .head("http://www.url.com/page")
         .send()?

--- a/fixtures/rust_output/multipart_with_headers.rs
+++ b/fixtures/rust_output/multipart_with_headers.rs
@@ -1,0 +1,22 @@
+extern crate reqwest;
+use reqwest::{header, multipart};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("Authorization", "Bearer ACCESS_TOKEN".parse().unwrap());
+    headers.insert("X-Nice", "Header".parse().unwrap());
+
+    let form = multipart::Form::new()
+        .text("attributes", "{\"name\":\"tigers.jpeg\", \"parent\":{\"id\":\"11446498\"}}")
+        .file("file", "myfile.jpg")?;
+
+    let res = reqwest::Client::new()
+        .post("https://upload.box.com/api/2.0/files/content")
+        .headers(headers)
+        .multipart(form)
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}

--- a/fixtures/rust_output/post_with_quotes_anywhere.rs
+++ b/fixtures/rust_output/post_with_quotes_anywhere.rs
@@ -1,12 +1,11 @@
 extern crate reqwest;
-use reqwest::headers::*;
+use reqwest::header;
 
-fn main() -> Result<(), reqwest::Error> {
-    let mut headers = HeaderMap::new();
-    headers.insert(A, "''a'".parse().unwrap());
-    headers.insert(B, "\"".parse().unwrap());
-    headers.insert(COOKIE, "x".parse().unwrap());
-    headers.insert(COOKIE, "y".parse().unwrap());
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut headers = header::HeaderMap::new();
+    headers.insert("A", "''a'".parse().unwrap());
+    headers.insert("B", "\"".parse().unwrap());
+    headers.insert(header::COOKIE, "x=1'; y=2\"".parse().unwrap());
 
     let res = reqwest::Client::new()
         .post("https://example.com")

--- a/fixtures/rust_output/post_with_quotes_anywhere.rs
+++ b/fixtures/rust_output/post_with_quotes_anywhere.rs
@@ -1,0 +1,21 @@
+extern crate reqwest;
+use reqwest::headers::*;
+
+fn main() -> Result<(), reqwest::Error> {
+    let mut headers = HeaderMap::new();
+    headers.insert(A, "''a'".parse().unwrap());
+    headers.insert(B, "\"".parse().unwrap());
+    headers.insert(COOKIE, "x".parse().unwrap());
+    headers.insert(COOKIE, "y".parse().unwrap());
+
+    let res = reqwest::Client::new()
+        .post("https://example.com")
+        .basic_auth("ol'", Some("asd\""))
+        .headers(headers)
+        .body("a=b&c=\"&d='")
+        .send()?
+        .text()?;
+    println!("{}", res);
+
+    Ok(())
+}

--- a/generators/php.js
+++ b/generators/php.js
@@ -1,5 +1,8 @@
 var util = require('../util')
 var querystring = require('querystring')
+const jsesc = require('jsesc')
+
+const quote = str => jsesc(str, { quotes: 'single' })
 
 var toPhp = function (curlCommand) {
   var request = util.parseCurlCommand(curlCommand)
@@ -10,14 +13,14 @@ var toPhp = function (curlCommand) {
     var i = 0
     var headerCount = Object.keys(request.headers).length
     for (var headerName in request.headers) {
-      headerString += "    '" + headerName + "' => '" + request.headers[headerName] + "'"
+      headerString += "    '" + headerName + "' => '" + quote(request.headers[headerName]) + "'"
       if (i < headerCount - 1) {
         headerString += ',\n'
       }
       i++
     }
     if (request.cookies) {
-      var cookieString = util.serializeCookies(request.cookies)
+      var cookieString = quote(util.serializeCookies(request.cookies))
       headerString += ",\n    'Cookie' => '" + cookieString + "'"
     }
     headerString += '\n);'
@@ -27,7 +30,7 @@ var toPhp = function (curlCommand) {
 
   var optionsString = false
   if (request.auth) {
-    var splitAuth = request.auth.split(':')
+    var splitAuth = request.auth.split(':').map(quote)
     var user = splitAuth[0] || ''
     var password = splitAuth[1] || ''
     optionsString = "$options = array('auth' => array('" + user + "', '" + password + "'));"
@@ -42,12 +45,12 @@ var toPhp = function (curlCommand) {
     dataString = '$data = array(\n'
     var dataCount = Object.keys(parsedQueryString).length
     if (dataCount === 1 && !parsedQueryString[Object.keys(parsedQueryString)[0]]) {
-      dataString = "$data = '" + request.data + "';"
+      dataString = "$data = '" + quote(request.data) + "';"
     } else {
       var dataIndex = 0
       for (var key in parsedQueryString) {
         var value = parsedQueryString[key]
-        dataString += "    '" + key + "' => '" + value.replace(/[\\"']/g, '\\$&') + "'"
+        dataString += "    '" + key + "' => '" + quote(value) + "'"
         if (dataIndex < dataCount - 1) {
           dataString += ',\n'
         }

--- a/generators/rust.js
+++ b/generators/rust.js
@@ -1,102 +1,106 @@
-var util = require('../util')
-const jsesc = require('jsesc')
+const util = require('../util')
+const jsesc = require('jsesc');
 
+const INDENTATION = ' '.repeat(4)
+const indent = (line, level = 1) => INDENTATION.repeat(level) + line
 const quote = str => jsesc(str, { quotes: 'double' })
 
-var toRust = function (curlCommand) {
-  var request = util.parseCurlCommand(curlCommand)
-  var rustCode = 'extern crate reqwest;\n'
+function toRust (curlCommand) {
+  const lines = ['extern crate reqwest;']
+  const request = util.parseCurlCommand(curlCommand)
 
-  if (request.headers || request.cookies) {
-    rustCode += 'use reqwest::headers::*;\n'
-  }
-  if (request.multipartUploads) {
-    rustCode += 'use reqwest::multipart;\n'
-  }
+  const hasHeaders = request.headers || request.cookies
 
-  rustCode += '\nfn main() -> Result<(), reqwest::Error> {\n'
+  {
+    // Generate imports.
+    const imports = [
+      { want: 'header', condition: hasHeaders },
+      { want: 'multipart', condition: !!request.multipartUploads }
+    ].filter(i => i.condition).map (i => i.want)
 
-  if (request.headers || request.cookies) {
-    rustCode += '    let mut headers = HeaderMap::new();\n'
-
-    for (var header in request.headers) {
-      rustCode += '    headers.insert(' + header.replace(/-/g, '_').toUpperCase() + ', "' + quote(request.headers[header]) + '".parse().unwrap());\n'
-    }
-
-    for (var cookie in request.cookies) {
-      rustCode += '    headers.insert(COOKIE, "' + quote(cookie) + '".parse().unwrap());\n'
+    if (imports.length > 1) {
+      lines.push(`use reqwest::{${imports.join(', ')}};`)
+    } else if (imports.length) {
+      lines.push(`use reqwest::${imports[0]};`)
     }
   }
 
-  if (request.multipartUploads) {
-    rustCode += '    let form = multipart::Form::new()'
+  lines.push('', 'fn main() -> Result<(), Box<dyn std::error::Error>> {')
 
-    for (var part in request.multipartUploads) {
-      if (part === 'image' || part === 'file') {
-        rustCode += '\n        .file("' + part + '", "' + request.multipartUploads[part].split('@')[1] + '")?'
-      } else {
-        rustCode += '\n        .text("' + quote(part) + '", "' + request.multipartUploads[part] + '")'
+  if (request.headers || request.cookies) {
+    lines.push(indent('let mut headers = header::HeaderMap::new();'))
+
+    for (let headerName in request.headers) {
+      const headerValue = quote(request.headers[headerName])
+      lines.push(indent(`headers.insert("${headerName}", "${headerValue}".parse().unwrap());`))
+    }
+
+    if (request.cookies) {
+      let cookies = Object.keys(request.cookies)
+        .map(key => `${key}=${request.cookies[key]}`)
+        .join('; ')
+      lines.push(indent(`headers.insert(header::COOKIE, "${quote(cookies)}".parse().unwrap());`))
+    }
+
+    lines.push('')
+  }
+
+  if (request.multipartUploads) {
+    lines.push(indent('let form = multipart::Form::new()'))
+    const parts = Object.keys(request.multipartUploads).map(partType => {
+      const partValue = request.multipartUploads[partType]
+      switch (partType) {
+      case 'image', 'file':
+        const path = partValue.split('@')[1]
+        return indent(`.file("${partType}", "${quote(path)}")?`, 2)
+      default:
+        return indent(`.text("${partType}", "${quote(partValue)}")`, 2)
       }
-    }
-    rustCode += ';\n'
+    })
+    parts[parts.length - 1] += ';'
+    lines.push(...parts, '')
   }
 
-  rustCode += '\n    let res = reqwest::Client::new()\n'
-
-  switch (request.method) {
-    case 'get':
-      rustCode += '        .get("' + quote(request.url) + '")'
-      break
-    case 'post':
-      rustCode += '        .post("' + quote(request.url) + '")'
-      break
-    case 'put':
-      rustCode += '        .put("' + quote(request.url) + '")'
-      break
-    case 'head':
-      rustCode += '        .head("' + quote(request.url) + '")'
-      break
-    case 'patch':
-      rustCode += '        .patch("' + quote(request.url) + '")'
-      break
-    case 'delete':
-      rustCode += '        .delete("' + quote(request.url) + '")'
-      break
-    default:
-      break
-  }
-  rustCode += '\n'
+  lines.push(indent('let res = reqwest::Client::new()'))
+  lines.push(indent(`.${request.method}("${quote(request.url)}")`, 2))
 
   if (request.auth) {
-    var splitAuth = request.auth.split(':').map(quote)
-    var user = splitAuth[0] || ''
-    var password = splitAuth[1] || ''
-    rustCode += '        .basic_auth("' + user + '", Some("' + password + '"))\n'
+    const [ user, password ] = request.auth.split(':', 2).map(quote)
+    lines.push(indent(`.basic_auth("${user || ''}", Some("${password || ''}"))`, 2))
   }
 
-  if (request.headers) {
-    rustCode += '        .headers(headers)\n'
+  if (hasHeaders) {
+    lines.push(indent('.headers(headers)', 2))
   }
 
   if (request.multipartUploads) {
-    rustCode += '        .multipart(form)\n'
+    lines.push(indent('.multipart(form)', 2))
   }
 
   if (request.data) {
-    if (typeof request.data === 'string') {
-      rustCode += '        .body("' + quote(request.data.replace(/\s/g, '')) + '")\n'
+    if (typeof request.data === 'string' && request.data.indexOf("\n") !== -1) {
+      // Use raw strings for multiline content
+      lines.push(
+        indent('.body(r#"', 2),
+        request.data,
+        '"#',
+        indent(')', 2)
+      )
     } else {
-      rustCode += '        .body("' + quote(request.data) + '")\n'
+      lines.push(indent(`.body("${quote(request.data)}")`, 2))
     }
   }
 
-  // Complete query builder and send
-  // text()? gets the body or response
-  rustCode += '        .send()?\n        .text()?;\n'
-  // Print the result to stdout
-  rustCode += '    println!("{}", res);\n\n    Ok(())\n}'
-  rustCode += '\n'
-  return rustCode
+  lines.push(
+    indent('.send()?', 2),
+    indent('.text()?;', 2),
+    indent('println!("{}", res);'),
+    '',
+    indent('Ok(())'),
+    '}'
+  )
+
+  return lines.join("\n") + "\n"
 }
 
 module.exports = toRust

--- a/generators/rust.js
+++ b/generators/rust.js
@@ -1,5 +1,5 @@
 const util = require('../util')
-const jsesc = require('jsesc');
+const jsesc = require('jsesc')
 
 const INDENTATION = ' '.repeat(4)
 const indent = (line, level = 1) => INDENTATION.repeat(level) + line
@@ -16,7 +16,7 @@ function toRust (curlCommand) {
     const imports = [
       { want: 'header', condition: hasHeaders },
       { want: 'multipart', condition: !!request.multipartUploads }
-    ].filter(i => i.condition).map (i => i.want)
+    ].filter(i => i.condition).map(i => i.want)
 
     if (imports.length > 1) {
       lines.push(`use reqwest::{${imports.join(', ')}};`)
@@ -30,13 +30,13 @@ function toRust (curlCommand) {
   if (request.headers || request.cookies) {
     lines.push(indent('let mut headers = header::HeaderMap::new();'))
 
-    for (let headerName in request.headers) {
+    for (const headerName in request.headers) {
       const headerValue = quote(request.headers[headerName])
       lines.push(indent(`headers.insert("${headerName}", "${headerValue}".parse().unwrap());`))
     }
 
     if (request.cookies) {
-      let cookies = Object.keys(request.cookies)
+      const cookies = Object.keys(request.cookies)
         .map(key => `${key}=${request.cookies[key]}`)
         .join('; ')
       lines.push(indent(`headers.insert(header::COOKIE, "${quote(cookies)}".parse().unwrap());`))
@@ -50,11 +50,13 @@ function toRust (curlCommand) {
     const parts = Object.keys(request.multipartUploads).map(partType => {
       const partValue = request.multipartUploads[partType]
       switch (partType) {
-      case 'image', 'file':
-        const path = partValue.split('@')[1]
-        return indent(`.file("${partType}", "${quote(path)}")?`, 2)
-      default:
-        return indent(`.text("${partType}", "${quote(partValue)}")`, 2)
+        case 'image':
+        case 'file': {
+          const path = partValue.split('@')[1]
+          return indent(`.file("${partType}", "${quote(path)}")?`, 2)
+        }
+        default:
+          return indent(`.text("${partType}", "${quote(partValue)}")`, 2)
       }
     })
     parts[parts.length - 1] += ';'
@@ -65,7 +67,7 @@ function toRust (curlCommand) {
   lines.push(indent(`.${request.method}("${quote(request.url)}")`, 2))
 
   if (request.auth) {
-    const [ user, password ] = request.auth.split(':', 2).map(quote)
+    const [user, password] = request.auth.split(':', 2).map(quote)
     lines.push(indent(`.basic_auth("${user || ''}", Some("${password || ''}"))`, 2))
   }
 
@@ -78,7 +80,7 @@ function toRust (curlCommand) {
   }
 
   if (request.data) {
-    if (typeof request.data === 'string' && request.data.indexOf("\n") !== -1) {
+    if (typeof request.data === 'string' && request.data.indexOf('\n') !== -1) {
       // Use raw strings for multiline content
       lines.push(
         indent('.body(r#"', 2),
@@ -100,7 +102,7 @@ function toRust (curlCommand) {
     '}'
   )
 
-  return lines.join("\n") + "\n"
+  return lines.join('\n') + '\n'
 }
 
 module.exports = toRust


### PR DESCRIPTION
**WARNING: this depends on #176**. Please only consider this PR after the other is reviewed. Otherwise, only see the diff of 6ec49df and a094cdc.

This PR refactors the Rust generator. Summary of the changes:
- Switched to modern ES6 syntax.
- Ensures that the resulting Rust code compiles. (Some code samples didn't)
- Switched error type from `reqwest::Error` to `Box<dyn std::error::Error>` as otherwise the `multipart` generator wouldn't work.
- Implemented proper support for multiline bodies with raw strings.
- Optimized import (`use`) generation.

Hopefully this is of your liking!
