### PR TITLE
Construct CookieField from Cookie in HTTPInterface [MATLAB]

### DIFF
--- a/fixtures/matlab_output/get_with_browser_headers.m
+++ b/fixtures/matlab_output/get_with_browser_headers.m
@@ -46,7 +46,7 @@ header = [
     ])
     HeaderField('Referer', 'http://www.wikipedia.org/')
     HeaderField('Connection', 'keep-alive')
-    field.CookieField(char(join(join(cookies, '='), '; ')))
+    field.CookieField(cellfun(@(x) Cookie(x{:}), num2cell(cookies, 2))
 ]';
 uri = URI('http://en.wikipedia.org/');
 response = RequestMessage('get', header).send(uri.EncodedURI);

--- a/fixtures/matlab_output/post_data_binary_with_equals.m
+++ b/fixtures/matlab_output/post_data_binary_with_equals.m
@@ -97,7 +97,7 @@ header = [
     HeaderField('DNT', '1')
     HeaderField('X-OWA-ClientBegin', '2016-11-27T07:17:02.513')
     HeaderField('X-OWA-Attempt', '1')
-    field.CookieField(char(join(join(cookies, '='), '; ')))
+    field.CookieField(cellfun(@(x) Cookie(x{:}), num2cell(cookies, 2))
 ]';
 uri = URI('https://localhost/api/service.svc', QueryParameter(params'));
 body = StringProvider('{"__type":"CreateItemJsonRequest:#Exchange","Header":{"__type":"JsonRequestHeaders:#Exchange","RequestServerVersion":"Exchange2013","TimeZoneContext":{"__type":"TimeZoneContext:#Exchange","TimeZoneDefinition":{"__type":"TimeZoneDefinitionType:#Exchange","Id":"France Standard Time"}}},"Body":{"__type":"CreateItemRequest:#Exchange","Items":[{"__type":"Message:#Exchange","Subject":"API","Body":{"__type":"BodyContentType:#Exchange","BodyType":"HTML","Value":"<html><head><meta http-equiv=\\"Content-Type\\" content=\\"text/html; charset=UTF-8\\"><style type=\\"text/css\\" style=\\"display:none\\"><!-- p { margin-top: 0px; margin-bottom: 0px; }--></style></head><body dir=\\"ltr\\" style=\\"font-size:12pt;color:#000000;background-color:#FFFFFF;font-family:Calibri,Arial,Helvetica,sans-serif;\\"><p>API Test for NickC<br></p></body></html>"},"Importance":"Normal","From":null,"ToRecipients":[{"Name":"George LUCAS","EmailAddress":"George.LUCAS@nih.mail.edu.fr","RoutingType":"SMTP","MailboxType":"Mailbox","OriginalDisplayName":"George.LUCAS@nih.mail.edu.fr","SipUri":" "}],"CcRecipients":[],"BccRecipients":[],"Sensitivity":"Normal","IsDeliveryReceiptRequested":false,"IsReadReceiptRequested":false}],"ClientSupportsIrm":true,"OutboundCharset":"AutoDetect","MessageDisposition":"SendAndSaveCopy","ComposeOperation":"newMail"}}');

--- a/generators/matlab/httpinterface.js
+++ b/generators/matlab/httpinterface.js
@@ -46,11 +46,14 @@ const prepareHeaders = (request) => {
     } else {
       header += '\n    ' + headers.join('\n    ')
       if (request.cookies) {
-        header += `\n    field.CookieField(${cookieString})`
+        const cookieFieldParams = [
+          callFunction(null, 'cellfun', '@(x) Cookie(x{:}', ''),
+          callFunction(null, 'num2cell', ['cookies', '2'], ''),
+        ]
+        header += '\n    ' + callFunction(null, 'field.CookieField', cookieFieldParams, '')
       }
       header += '\n]\''
     }
-
     response = setVariableValue('header', header)
   }
 


### PR DESCRIPTION
Some requests send cookies without values, e.g. ` _sdsat_traffic_source=`.

In MATLAB `field.CookieField` is unable to a char vector containing a cookie with an empty value. Instead, it is supposed to take a `Cookie` vector as an input.

This Pull Request fixes the generated requests for `HTTPInterface` when a cookie is missing a value.