### PR TITLE
Fix indentation issue & missing brace [MATLAB]

### DIFF
--- a/fixtures/curl_commands/get_cookie_with_empty_value.txt
+++ b/fixtures/curl_commands/get_cookie_with_empty_value.txt
@@ -1,0 +1,1 @@
+curl -X GET "https://httpbin.org/cookies" -H "accept: application/json" -H 'Cookie: mysamplecookie=someValue; emptycookie=; otherCookie=2'

--- a/fixtures/matlab_output/get_cookie_with_empty_value.m
+++ b/fixtures/matlab_output/get_cookie_with_empty_value.m
@@ -1,0 +1,28 @@
+%% Web Access using Data Import and Export API
+cookies = {
+    'mysamplecookie' 'someValue'
+    'emptycookie' ''
+    'otherCookie' '2'
+};
+uri = 'https://httpbin.org/cookies';
+options = weboptions('HeaderFields', {
+    'accept' 'application/json'
+    'Cookie' char(join(join(cookies, '='), '; '))
+});
+response = webread(uri, options);
+
+%% HTTP Interface
+import matlab.net.*
+import matlab.net.http.*
+
+cookies = {
+    'mysamplecookie' 'someValue'
+    'emptycookie' ''
+    'otherCookie' '2'
+};
+header = [
+    HeaderField('accept', 'application/json')
+    field.CookieField(cellfun(@(x) Cookie(x{:}), num2cell(cookies, 2)))
+]';
+uri = URI('https://httpbin.org/cookies');
+response = RequestMessage('get', header).send(uri.EncodedURI);

--- a/fixtures/matlab_output/get_with_browser_headers.m
+++ b/fixtures/matlab_output/get_with_browser_headers.m
@@ -46,7 +46,7 @@ header = [
     ])
     HeaderField('Referer', 'http://www.wikipedia.org/')
     HeaderField('Connection', 'keep-alive')
-    field.CookieField(cellfun(@(x) Cookie(x{:}), num2cell(cookies, 2))
+    field.CookieField(cellfun(@(x) Cookie(x{:}), num2cell(cookies, 2)))
 ]';
 uri = URI('http://en.wikipedia.org/');
 response = RequestMessage('get', header).send(uri.EncodedURI);

--- a/fixtures/matlab_output/post_binary_file.m
+++ b/fixtures/matlab_output/post_binary_file.m
@@ -2,9 +2,9 @@
 uri = 'http://lodstories.isi.edu:3030/american-art/query';
 body = fileread('./sample.sparql');
 options = weboptions('HeaderFields', {
-        'Content-type' 'application/sparql-query'
-        'Accept' 'application/sparql-results+json'
-    });
+    'Content-type' 'application/sparql-query'
+    'Accept' 'application/sparql-results+json'
+});
 response = webwrite(uri, body, options);
 
 %% HTTP Interface

--- a/fixtures/matlab_output/post_data_binary_with_equals.m
+++ b/fixtures/matlab_output/post_data_binary_with_equals.m
@@ -97,7 +97,7 @@ header = [
     HeaderField('DNT', '1')
     HeaderField('X-OWA-ClientBegin', '2016-11-27T07:17:02.513')
     HeaderField('X-OWA-Attempt', '1')
-    field.CookieField(cellfun(@(x) Cookie(x{:}), num2cell(cookies, 2))
+    field.CookieField(cellfun(@(x) Cookie(x{:}), num2cell(cookies, 2)))
 ]';
 uri = URI('https://localhost/api/service.svc', QueryParameter(params'));
 body = StringProvider('{"__type":"CreateItemJsonRequest:#Exchange","Header":{"__type":"JsonRequestHeaders:#Exchange","RequestServerVersion":"Exchange2013","TimeZoneContext":{"__type":"TimeZoneContext:#Exchange","TimeZoneDefinition":{"__type":"TimeZoneDefinitionType:#Exchange","Id":"France Standard Time"}}},"Body":{"__type":"CreateItemRequest:#Exchange","Items":[{"__type":"Message:#Exchange","Subject":"API","Body":{"__type":"BodyContentType:#Exchange","BodyType":"HTML","Value":"<html><head><meta http-equiv=\\"Content-Type\\" content=\\"text/html; charset=UTF-8\\"><style type=\\"text/css\\" style=\\"display:none\\"><!-- p { margin-top: 0px; margin-bottom: 0px; }--></style></head><body dir=\\"ltr\\" style=\\"font-size:12pt;color:#000000;background-color:#FFFFFF;font-family:Calibri,Arial,Helvetica,sans-serif;\\"><p>API Test for NickC<br></p></body></html>"},"Importance":"Normal","From":null,"ToRecipients":[{"Name":"George LUCAS","EmailAddress":"George.LUCAS@nih.mail.edu.fr","RoutingType":"SMTP","MailboxType":"Mailbox","OriginalDisplayName":"George.LUCAS@nih.mail.edu.fr","SipUri":" "}],"CcRecipients":[],"BccRecipients":[],"Sensitivity":"Normal","IsDeliveryReceiptRequested":false,"IsReadReceiptRequested":false}],"ClientSupportsIrm":true,"OutboundCharset":"AutoDetect","MessageDisposition":"SendAndSaveCopy","ComposeOperation":"newMail"}}');

--- a/generators/matlab/httpinterface.js
+++ b/generators/matlab/httpinterface.js
@@ -46,10 +46,9 @@ const prepareHeaders = (request) => {
     } else {
       header += '\n    ' + headers.join('\n    ')
       if (request.cookies) {
-        const cookieFieldParams = [
-          callFunction(null, 'cellfun', '@(x) Cookie(x{:}', ''),
-          callFunction(null, 'num2cell', ['cookies', '2'], ''),
-        ]
+        const cookieFieldParams = callFunction(null, 'cellfun', [
+          '@(x) Cookie(x{:})', callFunction(null, 'num2cell', ['cookies', '2'], '')
+        ], '')
         header += '\n    ' + callFunction(null, 'field.CookieField', cookieFieldParams, '')
       }
       header += '\n]\''

--- a/generators/matlab/webservices.js
+++ b/generators/matlab/webservices.js
@@ -88,7 +88,11 @@ const parseWebOptions = (request) => {
   }
 
   if (Object.entries(headers).length > 0) {
-    options.HeaderFields = addCellArray(headers, ['Authorization', 'Cookie'], '', 2)
+    // If key is on the same line as 'weboptions', there is only one parameter
+    // otherwise keys are indented by one level in the next line.
+    // An extra indentation level is given to the values's new lines in cell array
+    const indentLevel = 1 + (Object.keys(options).length === 0 ? 0 : 1)
+    options.HeaderFields = addCellArray(headers, ['Authorization', 'Cookie'], '', indentLevel)
   }
 
   return options


### PR DESCRIPTION
In my previous PR I have missed the closing round brace for `field.CookieField`, which made a syntax error in the generated code. I have written a fixture `get_cookie_with_empty_value.m` which tests cookies with empty values. I have also ran the fixtures with `field.CookieField` in MATLAB to confirm they work and return the expected results from httpbin.org.

I also found that sometimes the indentation is not visually pleasing when a cell array is printed in `weboptions`. In this PR I check the count Name-Value pairs (NVP) used with `weboptions`. If only 1 NVP is used, the indentation is 1, otherwise the indentation is 2. Now the generated code visually nicer to read.