### PR TITLE
changed type of "params" from touple of touples to dictionary

### DIFF
--- a/generators/python.js
+++ b/generators/python.js
@@ -14,7 +14,7 @@ function repr (value) {
 }
 
 function getQueryDict (request) {
-  let queryDict = 'params = (\n'
+  let queryDict = 'params = {\n'
   for (const paramName in request.query) {
     const rawValue = request.query[paramName]
     let paramValue
@@ -23,9 +23,9 @@ function getQueryDict (request) {
     } else {
       paramValue = repr(rawValue)
     }
-    queryDict += '    (' + repr(paramName) + ', ' + paramValue + '),\n'
+    queryDict += '    ' + repr(paramName) + ': ' + paramValue + ',\n'
   }
-  queryDict += ')\n'
+  queryDict += '}\n'
   return queryDict
 }
 


### PR DESCRIPTION
The preferred type of **params** in requests is **dictionary**. currently params is a **touple of touples** which works without any issue but shows a warning on pyCharm.