### PR TITLE
Add Environment Variable Detection for Python

### DIFF
--- a/fixtures/curl_commands/get_with_env_var.txt
+++ b/fixtures/curl_commands/get_with_env_var.txt
@@ -1,0 +1,1 @@
+curl -X GET -H "Content-Type: application/json" -H "Authorization: Bearer $DO_API_TOKEN" "https://api.digitalocean.com/v2/images?type=distribution"

--- a/fixtures/python_output/get_with_env_var.py
+++ b/fixtures/python_output/get_with_env_var.py
@@ -1,0 +1,20 @@
+import os
+import requests
+
+DO_API_TOKEN = os.getenv('DO_API_TOKEN')
+
+headers = {
+    'Content-Type': 'application/json',
+    'Authorization': f"Bearer {DO_API_TOKEN}",
+}
+
+params = (
+    ('type', 'distribution'),
+)
+
+response = requests.get('https://api.digitalocean.com/v2/images', headers=headers, params=params)
+
+#NB. Original query string below. It seems impossible to parse and
+#reproduce query strings 100% accurately so the one below is given
+#in case the reproduced version is not "correct".
+# response = requests.get('https://api.digitalocean.com/v2/images?type=distribution', headers=headers)


### PR DESCRIPTION
In this PR, I was trying to resolve an idea proposed in https://github.com/NickCarneiro/curlconverter/issues/226 .

However, currently, in this PR, there are several assumptions that I made.

- Currently, the request parsing is handled by the `util.parseCurlCommand(curlCommand)` and as far as I understand, it does not take into account the environment variable (e.g. if we have something like `$RANDOM_VAR`, it will be parsed as is). I check the environment variable based on the `parseCurlCommand` result, which not give context whether `$RANDOM_VAR` is in the single or double quote, so I just assume any env-var like the word is an env-var. Ideally, we should just parse the one that inside the double-quote string (discussed [here](https://superuser.com/a/835589)).

- Also, I only parse the variable if it is in the value part of the cookie and header (the common usage). I am not sure whether to check the cookie/header key as well or other request parts as well.

Any feedback or followup discussion is greatly appreciated! 😄 

Thank you!