### PR TITLE
make cli act as a drop-in replacement for curl

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,15 @@
 `curlconverter` acts as a drop-in replacement for [`curl`](https://en.wikipedia.org/wiki/CURL) and outputs a Python, JavaScript, Go, Rust, PHP, Java, R, Elixir, Dart or MATLAB program instead:
 
 ```sh
-$ curlconverter python -X PUT --data "Hello, world!" example.com
+$ curlconverter -X PUT --data "Hello, world!" example.com
 import requests
 
 data = 'Hello, world!'
 
 response = requests.put('http://example.com', data=data)
 ```
+
+You can choose your desired output language by passing `--language <language>`.
 
 [![NPM version][npm-image]][npm-url]
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
-#  [![NPM version][npm-image]][npm-url][![Build Status](https://travis-ci.org/NickCarneiro/curlconverter.svg)](https://travis-ci.org/NickCarneiro/curlconverter)
+# curlconverter
 
-Convert cURL syntax to native Python, Go, PHP, JavaScript, R, Elixir and Dart HTTP code
+`curlconverter` acts as a drop-in replacement for [`curl`](https://en.wikipedia.org/wiki/CURL) and outputs a Python, JavaScript, Go, Rust, PHP, Java, R, Elixir, Dart or MATLAB program instead:
+
+```sh
+$ curlconverter python -X PUT --data "Hello, world!" example.com
+import requests
+
+data = 'Hello, world!'
+
+response = requests.put('http://example.com', data=data)
+```
+
+[![NPM version][npm-image]][npm-url]
 
 ## Live Demo
 
@@ -9,17 +20,25 @@ https://curl.trillworks.com
 ## Install
 
 ```sh
+$ npm install --global curlconverter
+```
+
+or
+
+```sh
 $ npm install --save curlconverter
 ```
 
+curlconverter requires Node.js 14.8+
 
 ## Usage
 
 ```js
 import * as curlconverter from 'curlconverter';
 
+// You can pass a string or an array
 curlconverter.toPython("curl 'http://en.wikipedia.org/' -H 'Accept-Encoding: gzip, deflate, sdch' -H 'Accept-Language: en-US,en;q=0.8' -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36' -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8' -H 'Referer: http://www.wikipedia.org/' -H 'Cookie: GeoIP=US:Albuquerque:35.1241:-106.7675:v4; uls-previous-languages=%5B%22en%22%5D; mediaWiki.user.sessionId=VaHaeVW3m0ymvx9kacwshZIDkv8zgF9y; centralnotice_buckets_by_campaign=%7B%22C14_enUS_dsk_lw_FR%22%3A%7B%22val%22%3A%220%22%2C%22start%22%3A1412172000%2C%22end%22%3A1422576000%7D%2C%22C14_en5C_dec_dsk_FR%22%3A%7B%22val%22%3A3%2C%22start%22%3A1417514400%2C%22end%22%3A1425290400%7D%2C%22C14_en5C_bkup_dsk_FR%22%3A%7B%22val%22%3A1%2C%22start%22%3A1417428000%2C%22end%22%3A1425290400%7D%7D; centralnotice_bannercount_fr12=22; centralnotice_bannercount_fr12-wait=14' -H 'Connection: keep-alive' --compressed");
-
+curlconverter.toPython(['curl', 'http://en.wikipedia.org/', '-H', 'Accept-Encoding: gzip, deflate, sdch', '-H', 'Accept-Language: en-US,en;q=0.8', '-H', 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36', '-H', 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8', '-H', 'Referer: http://www.wikipedia.org/', '-H', 'Cookie: GeoIP=US:Albuquerque:35.1241:-106.7675:v4; uls-previous-languages=%5B%22en%22%5D; mediaWiki.user.sessionId=VaHaeVW3m0ymvx9kacwshZIDkv8zgF9y; centralnotice_buckets_by_campaign=%7B%22C14_enUS_dsk_lw_FR%22%3A%7B%22val%22%3A%220%22%2C%22start%22%3A1412172000%2C%22end%22%3A1422576000%7D%2C%22C14_en5C_dec_dsk_FR%22%3A%7B%22val%22%3A3%2C%22start%22%3A1417514400%2C%22end%22%3A1425290400%7D%2C%22C14_en5C_bkup_dsk_FR%22%3A%7B%22val%22%3A1%2C%22start%22%3A1417428000%2C%22end%22%3A1425290400%7D%7D; centralnotice_bannercount_fr12=22; centralnotice_bannercount_fr12-wait=14', '-H', 'Connection: keep-alive', '--compressed'])
 ```
 
 Returns a string of Python code like:
@@ -52,12 +71,11 @@ response = requests.get('http://en.wikipedia.org/', headers=headers, cookies=coo
 
 > I'd rather write programs to write programs than write programs.
 >
->
-> Dick Sites, Digital Equipment Corporation, September 1985
+> — Dick Sites, Digital Equipment Corporation, September 1985
 
-Make sure you're running node 14 or greater. The test suite will fail on older versions of node.
+Make sure you're running **Node 14.8** or greater. The test suite will fail on older versions of Node.js because curlconverter uses [top-level `await`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await#top_level_await).
 
-If you add a new generator, make sure to update the list of supported languages in [cli.js](bin/cli.js) or else it won't be accessible from the command line. Further, you'll want to update test.js and index.js for your new generator to make it part of the testing.
+If you add a new generator, make sure to update the list of supported languages in [bin/cli.js](bin/cli.js) or else it won't be accessible from the command line. Further, you'll want to update test.js and index.js for your new generator to make it part of the testing.
 
 If you want to add new functionality, start with a test.
 
@@ -74,7 +92,6 @@ You can run a specific test with:
 npm test -- test_name
 # or
 node test.js test_name
-
 ```
 
 where `test_name` is a file (without the `.sh` extension) in `fixtures/curl_commands/`
@@ -91,7 +108,7 @@ I recommend setting this up with a debugger so you can see exactly what the pars
 Here's my Intellij run configuration for a single test:
 ![Screenshot of intellij debug configuration](/docs/intellijconfig.png)
 
-Before submitting a PR, please check that your JS code conforms to the code style enforced by [standardjs](https://standardjs.com) with
+Before submitting a PR, please check that your JS code conforms to the code style enforced by [StandardJS](https://standardjs.com) with
 
 ```sh
 npm run lint
@@ -136,7 +153,6 @@ If you get stuck, please reach out via email. I am always willing to hop on a Go
 ## License
 
 MIT © [Nick Carneiro](http://trillworks.com)
-
 
 [npm-url]: https://npmjs.org/package/curlconverter
 [npm-image]: https://badge.fury.io/js/curlconverter.svg

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -2,12 +2,7 @@
 
 import * as curlconverter from '../index.js'
 
-import yargs from 'yargs'
-import { hideBin } from 'yargs/helpers'
 import fs from 'fs'
-
-// sets a default in case -l/--langauge isn't passed
-const defaultLanguage = 'python'
 
 // used to map languages to functions
 // NOTE: make sure to update this when adding language support
@@ -17,38 +12,56 @@ const translate = {
   dart: 'toDart',
   elixir: 'toElixir',
   go: 'toGo',
+  java: 'toJava',
   json: 'toJsonString',
+  matlab: 'toMATLAB',
   node: 'toNodeFetch',
   'node-request': 'toNodeRequest',
   php: 'toPhp',
   python: 'toPython',
   r: 'toR',
   rust: 'toRust',
-  strest: 'toStrest',
-  matlab: 'toMATLAB',
-  java: 'toJava'
+  strest: 'toStrest'
 }
 
-const argv = yargs(hideBin(process.argv))
-  .scriptName('curlconverter')
-  .usage('Usage: $0 [-l <language>] [curl_command]')
-  .option('l', {
-    alias: 'language',
-    choices: Object.keys(translate),
-    demandOption: false,
-    default: defaultLanguage,
-    describe: 'the language to convert the curl command to',
-    type: 'string'
-  })
-  .positional('curl_command', {
-    describe: 'if no <curl_command> is passed, the script will read from stdin',
-    type: 'string'
-  })
-  .alias('h', 'help')
-  .help()
-  .argv
+const USAGE = `Usage: curlconverter [<language>] [curl_options...]
 
-const curl = argv._.length ? argv._[0] : fs.readFileSync(0, 'utf8')
-const generator = curlconverter[translate[argv.language]]
+language: the language to convert the curl command to. The choices are
+  ansible
+  browser
+  dart
+  elixir
+  go
+  java
+  json
+  matlab
+  node
+  node-request
+  php
+  python (the default)
+  r
+  rust
+  strest
+
+If no <curl_options> are passed, the script will read from stdin.`
+
+let language = 'python'
+let argv = process.argv.slice(2)
+if (argv.includes('--help') || argv.includes('-h')) {
+  console.log(USAGE.trim())
+  process.exit(0)
+}
+if (Object.prototype.hasOwnProperty.call(translate, argv[0])) {
+  [language, ...argv] = argv
+}
+
+// Warning for users using the pre-4.0 CLI
+if (argv.length === 1 && argv[0].startsWith('curl ')) {
+  console.error('warning: Passing a whole curl command as a single argument?')
+  console.error('warning: Pass options to curlconverter as if it was curl instead:')
+  console.error("warning: curlconverter 'curl example.com' -> curlconverter example.com")
+}
+const curl = argv.length ? ['curl', ...argv] : fs.readFileSync(0, 'utf8')
+const generator = curlconverter[translate[language]]
 const code = generator(curl)
 process.stdout.write(code)

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,30 +1,49 @@
 #!/usr/bin/env node
 
-import * as curlconverter from '../index.js'
+import { curlLongOpts, curlShortOpts, parseArgs, buildRequest, parseCurlCommand } from '../util.js'
+
+import { _toAnsible } from '../generators/ansible.js'
+import { _toBrowser } from '../generators/javascript/browser.js'
+import { _toDart } from '../generators/dart.js'
+import { _toElixir } from '../generators/elixir.js'
+import { _toGo } from '../generators/go.js'
+import { _toJava } from '../generators/java.js'
+import { _toJsonString } from '../generators/json.js'
+import { _toMATLAB } from '../generators/matlab/matlab.js'
+import { _toNodeFetch } from '../generators/javascript/node-fetch.js'
+import { _toNodeRequest } from '../generators/javascript/node-request.js'
+import { _toPhp } from '../generators/php.js'
+import { _toPython } from '../generators/python.js'
+import { _toR } from '../generators/r.js'
+import { _toRust } from '../generators/rust.js'
+import { _toStrest } from '../generators/strest.js'
 
 import fs from 'fs'
 
-// used to map languages to functions
+// sets a default in case --langauge isn't passed
+const defaultLanguage = 'python'
+
+// Maps options for --language to functions
 // NOTE: make sure to update this when adding language support
 const translate = {
-  ansible: 'toAnsible',
-  browser: 'toBrowser',
-  dart: 'toDart',
-  elixir: 'toElixir',
-  go: 'toGo',
-  java: 'toJava',
-  json: 'toJsonString',
-  matlab: 'toMATLAB',
-  node: 'toNodeFetch',
-  'node-request': 'toNodeRequest',
-  php: 'toPhp',
-  python: 'toPython',
-  r: 'toR',
-  rust: 'toRust',
-  strest: 'toStrest'
+  ansible: _toAnsible,
+  browser: _toBrowser,
+  dart: _toDart,
+  elixir: _toElixir,
+  go: _toGo,
+  java: _toJava,
+  json: _toJsonString,
+  matlab: _toMATLAB,
+  node: _toNodeFetch,
+  'node-request': _toNodeRequest,
+  php: _toPhp,
+  python: _toPython,
+  r: _toR,
+  rust: _toRust,
+  strest: _toStrest
 }
 
-const USAGE = `Usage: curlconverter [<language>] [curl_options...]
+const USAGE = `Usage: curlconverter [--language <language>] [curl_options...]
 
 language: the language to convert the curl command to. The choices are
   ansible
@@ -45,23 +64,43 @@ language: the language to convert the curl command to. The choices are
 
 If no <curl_options> are passed, the script will read from stdin.`
 
-let language = 'python'
-let argv = process.argv.slice(2)
-if (argv.includes('--help') || argv.includes('-h')) {
+const curlConverterLongOpts = {
+  language: { type: 'string', name: 'language' }
+}
+
+const argv = process.argv.slice(2)
+const parsedArguments = parseArgs(argv, [{ ...curlLongOpts, ...curlConverterLongOpts }, curlShortOpts])
+if (parsedArguments.help) {
   console.log(USAGE.trim())
   process.exit(0)
 }
-if (Object.prototype.hasOwnProperty.call(translate, argv[0])) {
-  [language, ...argv] = argv
+
+const language = Object.prototype.hasOwnProperty.call(parsedArguments, 'language') ? parsedArguments.language : defaultLanguage
+if (!Object.prototype.hasOwnProperty.call(translate, language)) {
+  console.error('error: unexpected --language: ' + JSON.stringify(language))
+  console.error('error: must be one of: ' + Object.keys(translate).join(', '))
+  process.exit(1)
+}
+
+// If curlConverterLongOpts were the only args passed, read from stdin
+let request
+for (const opt of Object.keys(curlConverterLongOpts)) {
+  delete parsedArguments[opt]
+}
+if (!Object.keys(parsedArguments).length) {
+  const input = fs.readFileSync(0, 'utf8')
+  request = parseCurlCommand(input)
+} else {
+  request = buildRequest(parsedArguments)
 }
 
 // Warning for users using the pre-4.0 CLI
-if (argv.length === 1 && argv[0].startsWith('curl ')) {
+if (request.url && request.url.startsWith('curl ')) {
   console.error('warning: Passing a whole curl command as a single argument?')
   console.error('warning: Pass options to curlconverter as if it was curl instead:')
   console.error("warning: curlconverter 'curl example.com' -> curlconverter example.com")
 }
-const curl = argv.length ? ['curl', ...argv] : fs.readFileSync(0, 'utf8')
-const generator = curlconverter[translate[language]]
-const code = generator(curl)
+
+const generator = translate[language]
+const code = generator(request)
 process.stdout.write(code)

--- a/extract_curl_args.py
+++ b/extract_curl_args.py
@@ -289,9 +289,9 @@ if __name__ == "__main__":
     # for tag, version in
     #     old_aliases = fill_out_aliases(parse_aliases(f), add_no_options)
 
-    js_params_lines = list(format_as_js(long_args, "opts", indent_type="  "))
+    js_params_lines = list(format_as_js(long_args, "curlLongOpts", indent_type="  "))
     js_params_lines += [""]  # separate by a newline
-    js_params_lines += list(format_as_js(short_args, "shortOpts", indent_type="  "))
+    js_params_lines += list(format_as_js(short_args, "curlShortOpts", indent_type="  "))
 
     new_lines = []
     with open(OUTPUT_FILE) as f:

--- a/generators/ansible.js
+++ b/generators/ansible.js
@@ -16,12 +16,15 @@ function getDataString (request) {
   return request.data
 }
 
-export const toAnsible = curlCommand => {
-  const request = util.parseCurlCommand(curlCommand)
+export const _toAnsible = request => {
   var convertedData
   if (request.data && typeof request.data === 'string') {
     convertedData = getDataString(request)
   }
   var result = nunjucks.renderString(ansibleTemplate, { request: request, data: convertedData })
   return result
+}
+export const toAnsible = curlCommand => {
+  const request = util.parseCurlCommand(curlCommand)
+  return _toAnsible(request)
 }

--- a/generators/dart.js
+++ b/generators/dart.js
@@ -10,8 +10,7 @@ function repr (value) {
   }
 }
 
-export const toDart = curlCommand => {
-  const r = util.parseCurlCommand(curlCommand)
+export const _toDart = r => {
   let s = ''
 
   if (r.auth || r.isDataBinary) s += "import 'dart:convert';\n"
@@ -113,4 +112,8 @@ export const toDart = curlCommand => {
     '}'
 
   return s + '\n'
+}
+export const toDart = curlCommand => {
+  const r = util.parseCurlCommand(curlCommand)
+  return _toDart(r)
 }

--- a/generators/elixir.js
+++ b/generators/elixir.js
@@ -206,8 +206,7 @@ ${data.join(',\n')}
   return dataString
 }
 
-export var toElixir = curlCommand => {
-  var request = util.parseCurlCommand(curlCommand)
+export const _toElixir = request => {
   // curl automatically prepends 'http' if the scheme is missing, but python fails and returns an error
   // we tack it on here to mimic curl
   if (!request.url.match(/https?:/)) {
@@ -230,4 +229,8 @@ response = HTTPoison.request(request)
 `
 
   return template
+}
+export var toElixir = curlCommand => {
+  var request = util.parseCurlCommand(curlCommand)
+  return _toElixir(request)
 }

--- a/generators/go.js
+++ b/generators/go.js
@@ -1,8 +1,7 @@
 import * as util from '../util.js'
 import jsesc from 'jsesc'
 
-export const toGo = curlCommand => {
-  const request = util.parseCurlCommand(curlCommand)
+export const _toGo = request => {
   let goCode = 'package main\n\n'
   goCode += 'import (\n\t"fmt"\n\t"io/ioutil"\n\t"log"\n\t"net/http"\n)\n\n'
   goCode += 'func main() {\n'
@@ -48,4 +47,8 @@ export const toGo = curlCommand => {
   goCode += '}'
 
   return goCode + '\n'
+}
+export const toGo = curlCommand => {
+  const request = util.parseCurlCommand(curlCommand)
+  return _toGo(request)
 }

--- a/generators/java.js
+++ b/generators/java.js
@@ -4,8 +4,7 @@ import jsesc from 'jsesc'
 
 const doubleQuotes = str => jsesc(str, { quotes: 'double' })
 
-export const toJava = curlCommand => {
-  const request = util.parseCurlCommand(curlCommand)
+export const _toJava = request => {
   let javaCode = ''
 
   if (request.auth) {
@@ -80,4 +79,8 @@ export const toJava = curlCommand => {
   javaCode += '}'
 
   return javaCode + '\n'
+}
+export const toJava = curlCommand => {
+  const request = util.parseCurlCommand(curlCommand)
+  return _toJava(request)
 }

--- a/generators/javascript/browser.js
+++ b/generators/javascript/browser.js
@@ -1,7 +1,6 @@
-import { toJsFetch } from "./fetch.js";
+import { _toJsFetch, toJsFetch } from "./fetch.js";
 
-export const toBrowser = curlCommand => {
-  const browserCode = toJsFetch(curlCommand)
-
-  return browserCode
+export {
+  _toJsFetch as _toBrowser,
+  toJsFetch as toBrowser
 }

--- a/generators/javascript/fetch.js
+++ b/generators/javascript/fetch.js
@@ -1,9 +1,7 @@
 import * as util from "../../util.js";
 import jsesc from "jsesc";
 
-export const toJsFetch = curlCommand => {
-  const request = util.parseCurlCommand(curlCommand)
-
+export const _toJsFetch = request => {
   let jsFetchCode = ''
 
   if (request.data) {
@@ -76,4 +74,9 @@ export const toJsFetch = curlCommand => {
   jsFetchCode += ');'
 
   return jsFetchCode + '\n'
+}
+
+export const toJsFetch = curlCommand => {
+  const request = util.parseCurlCommand(curlCommand)
+  return _toJsFetch(request)
 }

--- a/generators/javascript/node-fetch.js
+++ b/generators/javascript/node-fetch.js
@@ -1,8 +1,11 @@
-import { toJsFetch } from "./fetch.js";
+import { _toJsFetch } from "./fetch.js";
 
-export const toNodeFetch = curlCommand => {
+export const _toNodeFetch = request => {
   let nodeFetchCode = 'var fetch = require(\'node-fetch\');\n\n'
-  nodeFetchCode += toJsFetch(curlCommand)
-
+  nodeFetchCode += _toJsFetch(request)
   return nodeFetchCode
+}
+export const toNodeFetch = curlCommand => {
+  const request = util.parseCurlCommand(curlCommand)
+  return _toNodeFetch(request)
 }

--- a/generators/javascript/node-request.js
+++ b/generators/javascript/node-request.js
@@ -1,8 +1,7 @@
 import * as util from "../../util.js";
 import jsesc from "jsesc";
 
-export const toNodeRequest = curlCommand => {
-  const request = util.parseCurlCommand(curlCommand)
+export const _toNodeRequest = request => {
   let nodeRequestCode = 'var request = require(\'request\');\n\n'
   if (request.headers || request.cookies) {
     nodeRequestCode += 'var headers = {\n'
@@ -68,4 +67,8 @@ export const toNodeRequest = curlCommand => {
   nodeRequestCode += 'request(options, callback);'
 
   return nodeRequestCode + '\n'
+}
+export const toNodeRequest = curlCommand => {
+  const request = util.parseCurlCommand(curlCommand)
+  return _toNodeRequest(request)
 }

--- a/generators/json.js
+++ b/generators/json.js
@@ -96,9 +96,7 @@ function getFilesString (request) {
   return data
 }
 
-export const toJsonString = curlCommand => {
-  const request = util.parseCurlCommand(curlCommand)
-
+export const _toJsonString = request => {
   const requestJson = {}
 
   // curl automatically prepends 'http' if the scheme is missing, but python fails and returns an error
@@ -158,4 +156,8 @@ export const toJsonString = curlCommand => {
   }
 
   return JSON.stringify(Object.keys(requestJson).length ? requestJson : '{}', null, 4) + '\n'
+}
+export const toJsonString = curlCommand => {
+  const request = util.parseCurlCommand(curlCommand)
+  return _toJsonString(request)
 }

--- a/generators/matlab/matlab.js
+++ b/generators/matlab/matlab.js
@@ -14,8 +14,11 @@ if (!Array.prototype.flat) {
   });
 }
 
-export const toMATLAB = curlCommand => {
-  const request = util.parseCurlCommand(curlCommand)
+export const _toMATLAB = request => {
   const lines = toWebServices(request).concat('', toHTTPInterface(request))
   return lines.flat().filter(line => line !== null).join('\n')
+}
+export const toMATLAB = curlCommand => {
+  const request = util.parseCurlCommand(curlCommand)
+  return _toMATLAB(request)
 }

--- a/generators/php.js
+++ b/generators/php.js
@@ -5,9 +5,7 @@ import jsesc from 'jsesc'
 
 const quote = str => jsesc(str, { quotes: 'single' })
 
-export const toPhp = curlCommand => {
-  const request = util.parseCurlCommand(curlCommand)
-
+export const _toPhp = request => {
   let headerString = false
   if (request.headers) {
     headerString = '$headers = array(\n'
@@ -81,4 +79,8 @@ export const toPhp = curlCommand => {
   phpCode += requestLine
 
   return phpCode + '\n'
+}
+export const toPhp = curlCommand => {
+  const request = util.parseCurlCommand(curlCommand)
+  return _toPhp(request)
 }

--- a/generators/python.js
+++ b/generators/python.js
@@ -189,9 +189,7 @@ function detectEnvVar (inputString) {
   return [detectedVariables, modifiedString.join('')]
 }
 
-export const toPython = curlCommand => {
-  const request = util.parseCurlCommand(curlCommand)
-
+export const _toPython = request => {
   // Currently, only assuming that the env-var only used in
   // the value part of cookies, params, or body
   const osVariables = new Set()
@@ -324,4 +322,8 @@ export const toPython = curlCommand => {
   }
 
   return pythonCode + '\n'
+}
+export const toPython = curlCommand => {
+  const request = util.parseCurlCommand(curlCommand)
+  return _toPython(request)
 }

--- a/generators/r.js
+++ b/generators/r.js
@@ -113,8 +113,7 @@ function getFilesString (request) {
   return filesString
 }
 
-export const toR = curlCommand => {
-  const request = util.parseCurlCommand(curlCommand)
+export const _toR = request => {
   let cookieDict
   if (request.cookies) {
     cookieDict = 'cookies = c(\n'
@@ -211,4 +210,8 @@ export const toR = curlCommand => {
   }
 
   return rstatsCode + '\n'
+}
+export const toR = curlCommand => {
+  const request = util.parseCurlCommand(curlCommand)
+  return _toR(request)
 }

--- a/generators/rust.js
+++ b/generators/rust.js
@@ -6,10 +6,8 @@ const INDENTATION = ' '.repeat(4)
 const indent = (line, level = 1) => INDENTATION.repeat(level) + line
 const quote = str => jsesc(str, { quotes: 'double' })
 
-export const toRust = curlCommand => {
+export const _toRust = request => {
   const lines = ['extern crate reqwest;']
-  const request = util.parseCurlCommand(curlCommand)
-
   const hasHeaders = request.headers || request.cookies
   {
     // Generate imports.
@@ -101,4 +99,8 @@ export const toRust = curlCommand => {
   )
 
   return lines.join('\n') + '\n'
+}
+export const toRust = curlCommand => {
+  const request = util.parseCurlCommand(curlCommand)
+  return _toRust(request)
 }

--- a/generators/strest.js
+++ b/generators/strest.js
@@ -43,8 +43,7 @@ function getQueryList (request) {
   return queryList
 }
 
-export const toStrest = curlCommand => {
-  const request = util.parseCurlCommand(curlCommand)
+export const _toStrest = request => {
   const response = { version: 2 }
   if (request.insecure) {
     response.allowInsecure = true
@@ -97,4 +96,8 @@ export const toStrest = curlCommand => {
 
   const yamlString = yaml.stringify(response, 100, 2)
   return yamlString
+}
+export const toStrest = curlCommand => {
+  const request = util.parseCurlCommand(curlCommand)
+  return _toStrest(request)
 }

--- a/index.js
+++ b/index.js
@@ -1,9 +1,11 @@
 import { toAnsible } from './generators/ansible.js'
+import { toBrowser } from './generators/javascript/browser.js'
 import { toDart } from './generators/dart.js'
 import { toElixir } from './generators/elixir.js'
-import { toBrowser } from './generators/javascript/browser.js'
 import { toGo } from './generators/go.js'
+import { toJava } from './generators/java.js'
 import { toJsonString } from './generators/json.js'
+import { toMATLAB } from './generators/matlab/matlab.js'
 import { toNodeFetch } from './generators/javascript/node-fetch.js'
 import { toNodeRequest } from './generators/javascript/node-request.js'
 import { toPhp } from './generators/php.js'
@@ -11,23 +13,21 @@ import { toPython } from './generators/python.js'
 import { toR } from './generators/r.js'
 import { toRust } from './generators/rust.js'
 import { toStrest } from './generators/strest.js'
-import { toMATLAB } from './generators/matlab/matlab.js'
-import { toJava } from './generators/java.js'
 
 export {
   toAnsible,
   toBrowser,
   toDart,
+  toElixir,
   toGo,
+  toJava,
   toJsonString,
+  toMATLAB,
   toNodeFetch,
   toNodeRequest,
   toPhp,
   toPython,
-  toElixir,
   toR,
   toRust,
-  toStrest,
-  toMATLAB,
-  toJava
+  toStrest
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "curlconverter",
-  "version": "4.0.0-alpha.1",
+  "version": "4.0.0-alpha.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "curlconverter",
-      "version": "4.0.0-alpha.1",
+      "version": "4.0.0-alpha.3",
       "license": "MIT",
       "dependencies": {
         "cookie": "^0.4.1",
@@ -18,15 +18,18 @@
         "tree-sitter-bash": "^0.19.0",
         "tree-sitter-cli": "^0.20.0",
         "web-tree-sitter": "^0.19.4",
-        "yamljs": "^0.3.0",
-        "yargs": "^17.1.1"
+        "yamljs": "^0.3.0"
       },
       "bin": {
         "curlconverter": "bin/cli.js"
       },
       "devDependencies": {
         "standard": "^16.0.3",
-        "tape": "^5.3.1"
+        "tape": "^5.3.1",
+        "yargs": "^17.2.0"
+      },
+      "engines": {
+        "node": ">=14.8.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -208,6 +211,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
       "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -216,6 +220,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -453,6 +458,7 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -462,12 +468,14 @@
     "node_modules/cliui/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "node_modules/cliui/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -476,6 +484,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
       "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -497,6 +506,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -507,7 +517,8 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/commander": {
       "version": "5.1.0",
@@ -800,6 +811,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -1440,6 +1452,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -2817,6 +2830,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3232,6 +3246,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
       "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.0"
       },
@@ -3625,6 +3640,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -3640,12 +3656,14 @@
     "node_modules/wrap-ansi/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -3654,6 +3672,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
       "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -3693,6 +3712,7 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -3717,9 +3737,10 @@
       }
     },
     "node_modules/yargs": {
-      "version": "17.1.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.1.1.tgz",
-      "integrity": "sha512-c2k48R0PwKIqKhPMWjeiF6y2xY/gPMUlro0sgxqXpbOIohWiLNXWslsootttv7E1e73QPAMQSg5FeySbVcpsPQ==",
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.2.0.tgz",
+      "integrity": "sha512-UPeZv4h9Xv510ibpt5rdsUNzgD78nMa1rhxxCgvkKiq06hlKCEHJLiJ6Ub8zDg/wR6hedEI6ovnd2vCvJ4nusA==",
+      "dev": true,
       "dependencies": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
@@ -3737,6 +3758,7 @@
       "version": "20.2.9",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -3744,12 +3766,14 @@
     "node_modules/yargs/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "node_modules/yargs/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -3758,6 +3782,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
       "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -3910,12 +3935,14 @@
     "ansi-regex": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "dev": true
     },
     "ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "requires": {
         "color-convert": "^2.0.1"
       }
@@ -4079,6 +4106,7 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
       "requires": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -4088,17 +4116,20 @@
         "emoji-regex": {
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
         },
         "string-width": {
           "version": "4.2.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
           "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+          "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
@@ -4116,6 +4147,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "requires": {
         "color-name": "~1.1.4"
       }
@@ -4123,7 +4155,8 @@
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "commander": {
       "version": "5.1.0",
@@ -4350,7 +4383,8 @@
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -4841,7 +4875,8 @@
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
     },
     "get-intrinsic": {
       "version": "1.1.1",
@@ -5843,7 +5878,8 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
     },
     "resolve": {
       "version": "1.20.0",
@@ -6149,6 +6185,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
       "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.0"
       }
@@ -6470,6 +6507,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -6479,17 +6517,20 @@
         "emoji-regex": {
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
         },
         "string-width": {
           "version": "4.2.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
           "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+          "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
@@ -6521,7 +6562,8 @@
     "y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true
     },
     "yallist": {
       "version": "4.0.0",
@@ -6539,9 +6581,10 @@
       }
     },
     "yargs": {
-      "version": "17.1.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.1.1.tgz",
-      "integrity": "sha512-c2k48R0PwKIqKhPMWjeiF6y2xY/gPMUlro0sgxqXpbOIohWiLNXWslsootttv7E1e73QPAMQSg5FeySbVcpsPQ==",
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.2.0.tgz",
+      "integrity": "sha512-UPeZv4h9Xv510ibpt5rdsUNzgD78nMa1rhxxCgvkKiq06hlKCEHJLiJ6Ub8zDg/wR6hedEI6ovnd2vCvJ4nusA==",
+      "dev": true,
       "requires": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
@@ -6555,17 +6598,20 @@
         "emoji-regex": {
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
         },
         "string-width": {
           "version": "4.2.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
           "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+          "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
@@ -6577,7 +6623,8 @@
     "yargs-parser": {
       "version": "20.2.9",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curlconverter",
-  "version": "4.0.0-alpha.1",
+  "version": "4.0.0-alpha.3",
   "description": "convert curl syntax to native python and javascript http code",
   "homepage": "https://github.com/NickCarneiro/curlconverter",
   "author": {
@@ -19,6 +19,9 @@
     "converter"
   ],
   "type": "module",
+  "engines": {
+    "node": ">=14.8.0"
+  },
   "dependencies": {
     "cookie": "^0.4.1",
     "jsesc": "^3.0.2",
@@ -29,12 +32,12 @@
     "tree-sitter-bash": "^0.19.0",
     "tree-sitter-cli": "^0.20.0",
     "web-tree-sitter": "^0.19.4",
-    "yamljs": "^0.3.0",
-    "yargs": "^17.1.1"
+    "yamljs": "^0.3.0"
   },
   "devDependencies": {
     "standard": "^16.0.3",
-    "tape": "^5.3.1"
+    "tape": "^5.3.1",
+    "yargs": "^17.2.0"
   },
   "scripts": {
     "test": "./node_modules/tape/bin/tape test.js",

--- a/util.js
+++ b/util.js
@@ -29,7 +29,7 @@ const pushProp = (obj, prop, value) => {
 }
 
 // BEGIN GENERATED CURL OPTIONS
-const opts = {
+const curlLongOpts = {
   url: { type: 'string' },
   'dns-ipv4-addr': { type: 'string' },
   'dns-ipv6-addr': { type: 'string' },
@@ -383,7 +383,7 @@ const opts = {
   next: { type: 'bool' }
 }
 
-const shortOpts = {
+const curlShortOpts = {
   0: 'http1.0',
   1: 'tlsv1',
   2: 'sslv2',
@@ -469,7 +469,7 @@ const canBeList = new Set([
 ])
 
 const shortened = {}
-for (const [opt, val] of Object.entries(opts)) {
+for (const [opt, val] of Object.entries(curlLongOpts)) {
   if (!has(val, 'name')) {
     val.name = opt
   }
@@ -487,12 +487,12 @@ for (const [opt, val] of Object.entries(opts)) {
   }
 }
 for (const [shortenedOpt, vals] of Object.entries(shortened)) {
-  if (!has(opts, shortenedOpt)) {
+  if (!has(curlLongOpts, shortenedOpt)) {
     if (vals.length === 1) {
-      opts[shortenedOpt] = vals[0]
+      curlLongOpts[shortenedOpt] = vals[0]
     } else if (vals.length > 1) {
       // More than one option shortens to this, it's ambiguous
-      opts[shortenedOpt] = null
+      curlLongOpts[shortenedOpt] = null
     }
   }
 }
@@ -666,20 +666,8 @@ const tokenizeBashStr = (curlCommand) => {
   return [cmdName.text.trim(), ...args.map(toVal)]
 }
 
-const parseCurlCommand = curlCommand => {
-  const [cmdName, ...args] = Array.isArray(curlCommand) ? curlCommand : tokenizeBashStr(curlCommand)
-  if (typeof cmdName === 'undefined') {
-    const errorMsg = Array.isArray(curlCommand) ? 'no arguments provided' : 'failed to parse input'
-    throw errorMsg
-  }
-  if (cmdName.trim() !== 'curl') {
-    const shortenedCmdName = cmdName.length > 30 ? cmdName.slice(0, 27) + '...' : cmdName
-    if (cmdName.startsWith('curl ')) {
-      throw 'command should begin with a single token "curl" but instead begins with ' + JSON.stringify(shortenedCmdName)
-    } else {
-      throw 'command should begin with "curl" but instead begins with ' + JSON.stringify(shortenedCmdName)
-    }
-  }
+const parseArgs = (args, opts) => {
+  const [longOpts, shortOpts] = opts || [curlLongOpts, curlShortOpts]
 
   const parsedArguments = {}
   for (let i = 0, stillflags = true; i < args.length; i++) {
@@ -690,7 +678,7 @@ const parseCurlCommand = curlCommand => {
            following (URL) argument to start with -. */
         stillflags = false
       } else if (arg.startsWith('--')) {
-        const longArg = opts[arg.slice(2)]
+        const longArg = longOpts[arg.slice(2)]
         if (longArg === null) {
           throw 'ambiguous argument ' + arg
         }
@@ -731,7 +719,7 @@ const parseCurlCommand = curlCommand => {
             throw 'option ' + arg + ': is unknown'
           }
           const shortFor = shortOpts[arg[j]]
-          const longArg = opts[shortFor]
+          const longArg = longOpts[shortFor]
           if (longArg.type === 'string') {
             let val
             if (j + 1 < arg.length) {
@@ -762,7 +750,10 @@ const parseCurlCommand = curlCommand => {
       parsedArguments[arg] = values[values.length - 1]
     }
   }
+  return parsedArguments
+}
 
+const buildRequest = parsedArguments => {
   // TODO: handle multiple URLs
   if (!parsedArguments.url || !parsedArguments.url.length) {
     // TODO: better error message (could be parsing fail)
@@ -932,6 +923,25 @@ const parseCurlCommand = curlCommand => {
   return request
 }
 
+const parseCurlCommand = (curlCommand) => {
+  const [cmdName, ...args] = Array.isArray(curlCommand) ? curlCommand : tokenizeBashStr(curlCommand)
+  if (typeof cmdName === 'undefined') {
+    const errorMsg = Array.isArray(curlCommand) ? 'no arguments provided' : 'failed to parse input'
+    throw errorMsg
+  }
+  if (cmdName.trim() !== 'curl') {
+    const shortenedCmdName = cmdName.length > 30 ? cmdName.slice(0, 27) + '...' : cmdName
+    if (cmdName.startsWith('curl ')) {
+      throw 'command should begin with a single token "curl" but instead begins with ' + JSON.stringify(shortenedCmdName)
+    } else {
+      throw 'command should begin with "curl" but instead begins with ' + JSON.stringify(shortenedCmdName)
+    }
+  }
+
+  const parsedArguments = parseArgs(args)
+  return buildRequest(parsedArguments)
+}
+
 const serializeCookies = cookieDict => {
   let cookieString = ''
   let i = 0
@@ -948,6 +958,10 @@ const serializeCookies = cookieDict => {
 }
 
 export {
+  curlLongOpts,
+  curlShortOpts,
+  parseArgs,
+  buildRequest,
   parseCurlCommand,
   serializeCookies
 }

--- a/util.js
+++ b/util.js
@@ -453,7 +453,7 @@ const shortOpts = {
 // TODO: extract this from curl's source code
 const canBeList = new Set([
   // TODO: unlike curl, we don't support multiple
-  // URLs and just take the first one.
+  // URLs and just take the last one.
   'url',
   'header', 'proxy-header',
   'form',
@@ -462,6 +462,7 @@ const canBeList = new Set([
   'resolve',
   'connect-to',
   // TODO: support multiple cookies
+  // https://github.com/NickCarneiro/curlconverter/issues/161
   // 'cookie',
   'quote',
   'telnet-option'
@@ -506,7 +507,92 @@ const toBoolean = opt => {
   return true
 }
 
-const parseCurlCommand = curlCommand => {
+// NOTE: this bash string parsing is probably not entirely correct.
+// We get the text as it appears in the bash source code,
+// which might have escaped newlines (if the string spans
+// multiple lines) and escaped quotes and maybe other
+// things I don't know about.
+const parseSingleQuoteString = (str) => {
+  const BACKSLASHES = /\\(\n|')/gs
+  const unescapeChar = (m) => m.charAt(1) === '\n' ? '' : m.charAt(1)
+  return str.slice(1, -1).replace(BACKSLASHES, unescapeChar)
+}
+const parseDoubleQuoteString = (str) => {
+  const BACKSLASHES = /\\(\n|\\|")/gs
+  const unescapeChar = (m) => m.charAt(1) === '\n' ? '' : m.charAt(1)
+  return str.slice(1, -1).replace(BACKSLASHES, unescapeChar)
+}
+// ANSI-C quoted strings look $'like this'.
+// Not all shells have them but bash does
+// https://www.gnu.org/software/bash/manual/html_node/ANSI_002dC-Quoting.html
+//
+// https://git.savannah.gnu.org/cgit/bash.git/tree/lib/sh/strtrans.c
+const parseAnsiCString = (str) => {
+  const ANSI_BACKSLASHES = /\\(\\|a|b|e|E|f|n|r|t|v|'|"|\?|[0-7]{1,3}|x[0-9A-Fa-f]{1,2}|u[0-9A-Fa-f]{1,4}|U[0-9A-Fa-f]{1,8}|c.)/gs
+  const unescapeChar = (m) => {
+    switch (m.charAt(1)) {
+      case '\\':
+        return '\\'
+      case 'a':
+        return '\a' // eslint-disable-line
+      case 'b':
+        return '\b'
+      case 'e':
+      case 'E':
+        return '\x1B'
+      case 'f':
+        return '\f'
+      case 'n':
+        return '\n'
+      case 'r':
+        return '\r'
+      case 't':
+        return '\t'
+      case 'v':
+        return '\v'
+      case "'":
+        return "'"
+      case '"':
+        return '"'
+      case '?':
+        return '?'
+      case 'c':
+        // bash handles all characters by considering the first byte
+        // of its UTF-8 input and can produce invalid UTF-8, whereas
+        // JavaScript stores strings in UTF-16
+        if (m.codePointAt(2) > 127) {
+          throw Error("non-ASCII control character in ANSI-C quoted string: '\\u{" + m.codePointAt(2).toString(16) + "}'")
+        }
+        // If this produces a 0x00 (null) character, it will cause bash to
+        // terminate the string at that character, but we return the null
+        // character in the result.
+        return m[2] === '?' ? '\x7F' : String.fromCodePoint(m[2].toUpperCase().codePointAt(0) & 0b00011111)
+      case 'x':
+      case 'u':
+      case 'U':
+        // Hexadecimal character literal
+        // Unlike bash, this will error if the the code point is greater than 10FFFF
+        return String.fromCodePoint(parseInt(m.slice(2), 16))
+      case '0':
+      case '1':
+      case '2':
+      case '3':
+      case '4':
+      case '5':
+      case '6':
+      case '7':
+        // Octal character literal
+        return String.fromCodePoint(parseInt(m.slice(1), 8) % 256)
+      default:
+        // There must be a mis-match between ANSI_BACKSLASHES and the switch statement
+        throw Error('unhandled character in ANSI-C escape code: ' + JSON.stringify(m))
+    }
+  }
+
+  return str.slice(2, -1).replace(ANSI_BACKSLASHES, unescapeChar)
+}
+
+const tokenizeBashStr = (curlCommand) => {
   const curlArgs = parser.parse(curlCommand)
   // The AST must be in a nice format, i.e.
   // (program
@@ -544,102 +630,12 @@ const parseCurlCommand = curlCommand => {
   }
   // TODO: add childrenForFieldName to tree-sitter node/web bindings and then
   // use that here instead
-  let [cmdName, ...args] = command.children
+  // TODO: you can have variable_assignment before the actual command
+  // MY_VAR=foo curl example.com
+  const [cmdName, ...args] = command.children
   if (cmdName.type !== 'command_name') {
     // TODO: better error message.
     throw "expected a 'command_name' AST node, got " + cmdName.type + ' instead'
-  }
-  // TODO: no trim? error message?
-  if (cmdName.text.trim() !== 'curl') {
-    return
-  }
-
-  // NOTE: this string parsing is probably not entirely correct.
-  // We get the text as it appears in the bash source code,
-  // which might have escaped newlines (if the string spans
-  // multiple lines) and escaped quotes and maybe other
-  // things I don't know about.
-  //
-  // TODO: it would be nice for tree-sitter to do this for us.
-  // https://github.com/tree-sitter/tree-sitter-bash/issues/101
-  const parseSingleQuoteString = (str) => {
-    const BACKSLASHES = /\\(\n|')/gs
-    const unescapeChar = (m) => m.charAt(1) === '\n' ? '' : m.charAt(1)
-    return str.slice(1, -1).replace(BACKSLASHES, unescapeChar)
-  }
-  const parseDoubleQuoteString = (str) => {
-    const BACKSLASHES = /\\(\n|\\|")/gs
-    const unescapeChar = (m) => m.charAt(1) === '\n' ? '' : m.charAt(1)
-    return str.slice(1, -1).replace(BACKSLASHES, unescapeChar)
-  }
-  // ANSI-C quoted strings look $'like this'.
-  // Not all shells have them but bash does
-  // https://www.gnu.org/software/bash/manual/html_node/ANSI_002dC-Quoting.html
-  //
-  // https://git.savannah.gnu.org/cgit/bash.git/tree/lib/sh/strtrans.c
-  const parseAnsiCString = (str) => {
-    const ANSI_BACKSLASHES = /\\(\\|a|b|e|E|f|n|r|t|v|'|"|\?|[0-7]{1,3}|x[0-9A-Fa-f]{1,2}|u[0-9A-Fa-f]{1,4}|U[0-9A-Fa-f]{1,8}|c.)/gs
-    const unescapeChar = (m) => {
-      switch (m.charAt(1)) {
-        case '\\':
-          return '\\'
-        case 'a':
-          return '\a' // eslint-disable-line
-        case 'b':
-          return '\b'
-        case 'e':
-        case 'E':
-          return '\x1B'
-        case 'f':
-          return '\f'
-        case 'n':
-          return '\n'
-        case 'r':
-          return '\r'
-        case 't':
-          return '\t'
-        case 'v':
-          return '\v'
-        case "'":
-          return "'"
-        case '"':
-          return '"'
-        case '?':
-          return '?'
-        case 'c':
-          // bash handles all characters by considering the first byte
-          // of its UTF-8 input and can produce invalid UTF-8, whereas
-          // JavaScript stores strings in UTF-16
-          if (m.codePointAt(2) > 127) {
-            throw Error("non-ASCII control character in ANSI-C quoted string: '\\u{" + m.codePointAt(2).toString(16) + "}'")
-          }
-          // If this produces a 0x00 (null) character, it will cause bash to
-          // terminate the string at that character, but we return the null
-          // character in the result.
-          return m[2] === '?' ? '\x7F' : String.fromCodePoint(m[2].toUpperCase().codePointAt(0) & 0b00011111)
-        case 'x':
-        case 'u':
-        case 'U':
-          // Hexadecimal character literal
-          // Unlike bash, this will error if the the code point is greater than 10FFFF
-          return String.fromCodePoint(parseInt(m.slice(2), 16))
-        case '0':
-        case '1':
-        case '2':
-        case '3':
-        case '4':
-        case '5':
-        case '6':
-        case '7':
-          // Octal character literal
-          return String.fromCodePoint(parseInt(m.slice(1), 8) % 256)
-        default:
-          // There must be a mis-match between ANSI_BACKSLASHES and the switch statement
-          throw Error('unhandled character in ANSI-C escape code: ' + JSON.stringify(m))
-      }
-    }
-
-    return str.slice(2, -1).replace(ANSI_BACKSLASHES, unescapeChar)
   }
 
   const toVal = (node) => {
@@ -656,6 +652,7 @@ const parseCurlCommand = curlCommand => {
         return node.text // TODO: handle variables properly downstream
       case 'concatenation':
         // item[]=1 turns into item=1 if we don't do this
+        // https://github.com/tree-sitter/tree-sitter-bash/issues/104
         if (node.children.every(n => n.type === 'word')) {
           return node.text
         }
@@ -663,10 +660,26 @@ const parseCurlCommand = curlCommand => {
       default:
         // console.error(curlCommand)
         // console.error(curlArgs.rootNode.toString())
-        throw 'unexpected argument type "' + node.type + '". Must be one of "word", "string", "raw_string", "ascii_c_string" or "simple_expansion"'
+        throw 'unexpected argument type ' + JSON.stringify(node.type) + '. Must be one of "word", "string", "raw_string", "ascii_c_string" or "simple_expansion"'
     }
   }
-  args = args.map(toVal)
+  return [cmdName.text.trim(), ...args.map(toVal)]
+}
+
+const parseCurlCommand = curlCommand => {
+  const [cmdName, ...args] = Array.isArray(curlCommand) ? curlCommand : tokenizeBashStr(curlCommand)
+  if (typeof cmdName === 'undefined') {
+    const errorMsg = Array.isArray(curlCommand) ? 'no arguments provided' : 'failed to parse input'
+    throw errorMsg
+  }
+  if (cmdName.trim() !== 'curl') {
+    const shortenedCmdName = cmdName.length > 30 ? cmdName.slice(0, 27) + '...' : cmdName
+    if (cmdName.startsWith('curl ')) {
+      throw 'command should begin with a single token "curl" but instead begins with ' + JSON.stringify(shortenedCmdName)
+    } else {
+      throw 'command should begin with "curl" but instead begins with ' + JSON.stringify(shortenedCmdName)
+    }
+  }
 
   const parsedArguments = {}
   for (let i = 0, stillflags = true; i < args.length; i++) {
@@ -755,7 +768,7 @@ const parseCurlCommand = curlCommand => {
     // TODO: better error message (could be parsing fail)
     throw 'no URL specified!'
   }
-  let url = parsedArguments.url[0]
+  let url = parsedArguments.url[parsedArguments.url.length - 1]
 
   let headers
   let cookieString


### PR DESCRIPTION
With this change you'll be able to paste a curl command into your shell, change "curl" to "curlconverter" and get a generated program instead of making a request. You can still pipe a command through stdin and you can optionally pass the desired output language using `--language` as before (Python is still the default). Note that if you try to use the old short option `-l`, it'll silently no longer work because `-l` is Curl's short option for `--list-only` which is a boolean so the language after `-l` will be interpreted as a URL (or an option if it happens to start with a `-`).