### PR TITLE
use file path relative to package location

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "curlconverter",
-  "version": "4.0.0-alpha.3",
+  "version": "4.0.0-alpha.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "curlconverter",
-      "version": "4.0.0-alpha.3",
+      "version": "4.0.0-alpha.4",
       "license": "MIT",
       "dependencies": {
         "cookie": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curlconverter",
-  "version": "4.0.0-alpha.3",
+  "version": "4.0.0-alpha.4",
   "description": "convert curl syntax to native python and javascript http code",
   "homepage": "https://github.com/NickCarneiro/curlconverter",
   "author": {

--- a/util.js
+++ b/util.js
@@ -1,12 +1,17 @@
+import path from 'path'
+import URL, { fileURLToPath } from 'url'
+
 import cookie from 'cookie'
-import URL from 'url'
-import querystring from 'query-string'
 import nunjucks from 'nunjucks'
+import querystring from 'query-string'
 import Parser from 'web-tree-sitter'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const bashGrammarFile = path.resolve(__dirname, 'tree-sitter-bash.wasm')
 
 // Top-level await is not available in Safari until 15 (TP)
 await Parser.init()
-const Bash = await Parser.Language.load('./tree-sitter-bash.wasm')
+const Bash = await Parser.Language.load(bashGrammarFile)
 const parser = new Parser()
 parser.setLanguage(Bash)
 


### PR DESCRIPTION
otherwise the command line tool doesn't work because it can't find ./tree-sitter-bash.wasm when you run it outside curlconverter/