### PR TITLE
use tree-sitter's Node bindings on Node and web bindings on the web

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # curlconverter
 
-`curlconverter` acts as a drop-in replacement for [`curl`](https://en.wikipedia.org/wiki/CURL) and outputs a Python, JavaScript, Go, Rust, PHP, Java, R, Elixir, Dart or MATLAB program instead:
+`curlconverter` transpiles [`curl`](https://en.wikipedia.org/wiki/CURL) Bash commands into programs in other programming languages.
 
 ```sh
 $ curlconverter -X PUT --data "Hello, world!" example.com
@@ -11,7 +11,7 @@ data = 'Hello, world!'
 response = requests.put('http://example.com', data=data)
 ```
 
-You can choose your desired output language by passing `--language <language>`.
+You can choose the output language by passing `--language <language>`. The options are Python `python` (the default), JavaScript `browser` `node` `node-request`, Go `go`, Rust `rust`, PHP `php`, Java `java`, R `r`, Elixir `elixir`, Dart `dart`, MATLAB `matlab` and a couple more.
 
 [![NPM version][npm-image]][npm-url]
 
@@ -21,29 +21,30 @@ https://curl.trillworks.com
 
 ## Install
 
+Install the command line tool with
+
 ```sh
 $ npm install --global curlconverter
 ```
 
-or
+Install the JavaScript library for use in your own projects with
 
 ```sh
 $ npm install --save curlconverter
 ```
 
-curlconverter requires Node.js 14.8+
-
 ## Usage
+
+The JavaScript API is a bunch of functions that take a string or an array
 
 ```js
 import * as curlconverter from 'curlconverter';
 
-// You can pass a string or an array
 curlconverter.toPython("curl 'http://en.wikipedia.org/' -H 'Accept-Encoding: gzip, deflate, sdch' -H 'Accept-Language: en-US,en;q=0.8' -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36' -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8' -H 'Referer: http://www.wikipedia.org/' -H 'Cookie: GeoIP=US:Albuquerque:35.1241:-106.7675:v4; uls-previous-languages=%5B%22en%22%5D; mediaWiki.user.sessionId=VaHaeVW3m0ymvx9kacwshZIDkv8zgF9y; centralnotice_buckets_by_campaign=%7B%22C14_enUS_dsk_lw_FR%22%3A%7B%22val%22%3A%220%22%2C%22start%22%3A1412172000%2C%22end%22%3A1422576000%7D%2C%22C14_en5C_dec_dsk_FR%22%3A%7B%22val%22%3A3%2C%22start%22%3A1417514400%2C%22end%22%3A1425290400%7D%2C%22C14_en5C_bkup_dsk_FR%22%3A%7B%22val%22%3A1%2C%22start%22%3A1417428000%2C%22end%22%3A1425290400%7D%7D; centralnotice_bannercount_fr12=22; centralnotice_bannercount_fr12-wait=14' -H 'Connection: keep-alive' --compressed");
 curlconverter.toPython(['curl', 'http://en.wikipedia.org/', '-H', 'Accept-Encoding: gzip, deflate, sdch', '-H', 'Accept-Language: en-US,en;q=0.8', '-H', 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36', '-H', 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8', '-H', 'Referer: http://www.wikipedia.org/', '-H', 'Cookie: GeoIP=US:Albuquerque:35.1241:-106.7675:v4; uls-previous-languages=%5B%22en%22%5D; mediaWiki.user.sessionId=VaHaeVW3m0ymvx9kacwshZIDkv8zgF9y; centralnotice_buckets_by_campaign=%7B%22C14_enUS_dsk_lw_FR%22%3A%7B%22val%22%3A%220%22%2C%22start%22%3A1412172000%2C%22end%22%3A1422576000%7D%2C%22C14_en5C_dec_dsk_FR%22%3A%7B%22val%22%3A3%2C%22start%22%3A1417514400%2C%22end%22%3A1425290400%7D%2C%22C14_en5C_bkup_dsk_FR%22%3A%7B%22val%22%3A1%2C%22start%22%3A1417428000%2C%22end%22%3A1425290400%7D%7D; centralnotice_bannercount_fr12=22; centralnotice_bannercount_fr12-wait=14', '-H', 'Connection: keep-alive', '--compressed'])
 ```
 
-Returns a string of Python code like:
+and return a string of code like:
 
 ```python
 import requests
@@ -75,7 +76,7 @@ response = requests.get('http://en.wikipedia.org/', headers=headers, cookies=coo
 >
 > — Dick Sites, Digital Equipment Corporation, September 1985
 
-Make sure you're running **Node 14.8** or greater. The test suite will fail on older versions of Node.js because curlconverter uses [top-level `await`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await#top_level_await).
+Make sure you're running **Node 14** or greater. The test suite will fail on older versions of Node.js.
 
 If you add a new generator, make sure to update the list of supported languages in [bin/cli.js](bin/cli.js) or else it won't be accessible from the command line. Further, you'll want to update test.js and index.js for your new generator to make it part of the testing.
 

--- a/browser-parser.js
+++ b/browser-parser.js
@@ -1,0 +1,10 @@
+import Parser from 'web-tree-sitter'
+
+// NOTE: Top-level await is not available in Safari until Safari 15
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await#browser_compatibility
+await Parser.init()
+const Bash = await Parser.Language.load('tree-sitter-bash.wasm')
+const parser = new Parser()
+parser.setLanguage(Bash)
+
+export default parser

--- a/index.js
+++ b/index.js
@@ -1,33 +1,15 @@
-import { toAnsible } from './generators/ansible.js'
-import { toBrowser } from './generators/javascript/browser.js'
-import { toDart } from './generators/dart.js'
-import { toElixir } from './generators/elixir.js'
-import { toGo } from './generators/go.js'
-import { toJava } from './generators/java.js'
-import { toJsonString } from './generators/json.js'
-import { toMATLAB } from './generators/matlab/matlab.js'
-import { toNodeFetch } from './generators/javascript/node-fetch.js'
-import { toNodeRequest } from './generators/javascript/node-request.js'
-import { toPhp } from './generators/php.js'
-import { toPython } from './generators/python.js'
-import { toR } from './generators/r.js'
-import { toRust } from './generators/rust.js'
-import { toStrest } from './generators/strest.js'
-
-export {
-  toAnsible,
-  toBrowser,
-  toDart,
-  toElixir,
-  toGo,
-  toJava,
-  toJsonString,
-  toMATLAB,
-  toNodeFetch,
-  toNodeRequest,
-  toPhp,
-  toPython,
-  toR,
-  toRust,
-  toStrest
-}
+export { toAnsible } from './generators/ansible.js'
+export { toBrowser } from './generators/javascript/browser.js'
+export { toDart } from './generators/dart.js'
+export { toElixir } from './generators/elixir.js'
+export { toGo } from './generators/go.js'
+export { toJava } from './generators/java.js'
+export { toJsonString } from './generators/json.js'
+export { toMATLAB } from './generators/matlab/matlab.js'
+export { toNodeFetch } from './generators/javascript/node-fetch.js'
+export { toNodeRequest } from './generators/javascript/node-request.js'
+export { toPhp } from './generators/php.js'
+export { toPython } from './generators/python.js'
+export { toR } from './generators/r.js'
+export { toRust } from './generators/rust.js'
+export { toStrest } from './generators/strest.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "string.prototype.startswith": "^1.0.0",
         "tree-sitter": "^0.19.0",
         "tree-sitter-bash": "^0.19.0",
-        "tree-sitter-cli": "^0.20.0",
         "web-tree-sitter": "^0.19.4",
         "yamljs": "^0.3.0"
       },
@@ -26,10 +25,8 @@
       "devDependencies": {
         "standard": "^16.0.3",
         "tape": "^5.3.1",
+        "tree-sitter-cli": "^0.20.0",
         "yargs": "^17.2.0"
-      },
-      "engines": {
-        "node": ">=14.8.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3420,6 +3417,7 @@
       "version": "0.20.0",
       "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.20.0.tgz",
       "integrity": "sha512-4D1qapWbJXZ5rrSUGM5rcw5Vuq/smzn9KbiFRhlON6KeuuXjra+KAtDYVrDgAoLIG4ku+jbEEGrJxCptUGi3dg==",
+      "dev": true,
       "hasInstallScript": true,
       "bin": {
         "tree-sitter": "cli.js"
@@ -6330,7 +6328,8 @@
     "tree-sitter-cli": {
       "version": "0.20.0",
       "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.20.0.tgz",
-      "integrity": "sha512-4D1qapWbJXZ5rrSUGM5rcw5Vuq/smzn9KbiFRhlON6KeuuXjra+KAtDYVrDgAoLIG4ku+jbEEGrJxCptUGi3dg=="
+      "integrity": "sha512-4D1qapWbJXZ5rrSUGM5rcw5Vuq/smzn9KbiFRhlON6KeuuXjra+KAtDYVrDgAoLIG4ku+jbEEGrJxCptUGi3dg==",
+      "dev": true
     },
     "tsconfig-paths": {
       "version": "3.11.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "curlconverter",
   "version": "4.0.0-alpha.5",
-  "description": "convert curl syntax to native python and javascript http code",
+  "description": "convert curl commands to Python, JavaScript, Go, PHP and other languages",
   "homepage": "https://github.com/NickCarneiro/curlconverter",
   "author": {
     "name": "Nick Carneiro",
@@ -11,7 +11,6 @@
   "repository": "NickCarneiro/curlconverter",
   "license": "MIT",
   "keywords": [
-    "curlconverter",
     "curl",
     "http",
     "requests",
@@ -19,9 +18,6 @@
     "converter"
   ],
   "type": "module",
-  "engines": {
-    "node": ">=14.8.0"
-  },
   "dependencies": {
     "cookie": "^0.4.1",
     "jsesc": "^3.0.2",
@@ -30,13 +26,13 @@
     "string.prototype.startswith": "^1.0.0",
     "tree-sitter": "^0.19.0",
     "tree-sitter-bash": "^0.19.0",
-    "tree-sitter-cli": "^0.20.0",
     "web-tree-sitter": "^0.19.4",
     "yamljs": "^0.3.0"
   },
   "devDependencies": {
     "standard": "^16.0.3",
     "tape": "^5.3.1",
+    "tree-sitter-cli": "^0.20.0",
     "yargs": "^17.2.0"
   },
   "scripts": {
@@ -44,7 +40,8 @@
     "lint": "./node_modules/standard/bin/cmd.js index.js generators/*.js bin/*.js test.js *.js",
     "lint:fix": "./node_modules/standard/bin/cmd.js --fix index.js generators/*.js bin/*.js test.js *.js"
   },
-  "bin": {
-    "curlconverter": "bin/cli.js"
+  "bin": "bin/cli.js",
+  "browser": {
+    "./parser.js": "./browser-parser.js"
   }
 }

--- a/parser.js
+++ b/parser.js
@@ -1,0 +1,7 @@
+import Parser from 'tree-sitter'
+import Bash from 'tree-sitter-bash'
+
+const parser = new Parser()
+parser.setLanguage(Bash)
+
+export default parser

--- a/util.js
+++ b/util.js
@@ -1,19 +1,11 @@
 import path from 'path'
-import URL, { fileURLToPath } from 'url'
+import URL from 'url'
 
 import cookie from 'cookie'
 import nunjucks from 'nunjucks'
 import querystring from 'query-string'
-import Parser from 'web-tree-sitter'
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url))
-const bashGrammarFile = path.resolve(__dirname, 'tree-sitter-bash.wasm')
-
-// Top-level await is not available in Safari until 15 (TP)
-await Parser.init()
-const Bash = await Parser.Language.load(bashGrammarFile)
-const parser = new Parser()
-parser.setLanguage(Bash)
+import parser from './parser.js'
 
 const env = nunjucks.configure(['templates/'], { // set folders with templates
   autoescape: false


### PR DESCRIPTION
tree-sitter has 2 JavaScript bindings, Node ones and WASM ones. The Node bindings don't require top-level `await` so curlconverter should once again support Node 12. Also the Node bindings are [allegedly faster][0] than running WASM under Node. We tell bundlers to use the WASM bindings when packaging for the browser using the [`browser` field][1] in package.json

[0]: https://github.com/tree-sitter/tree-sitter/tree/4ff217285705e06cd70fc77b5bf2e98b3add3a8a/lib/binding_web#running-wasm-in-nodejs
[1]: https://github.com/defunctzombie/package-browser-field-spec