### PR TITLE
report curl version in command line

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -20,8 +20,7 @@ import { _toStrest } from '../generators/strest.js'
 
 import fs from 'fs'
 
-// TODO: report which version of curl the args were extracted from
-const VERSION = '4.0.0-alpha.5'
+const VERSION = '4.0.0-alpha.6 (curl 7.79.1)'
 
 // sets a default in case --language isn't passed
 const defaultLanguage = 'python'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "curlconverter",
-  "version": "4.0.0-alpha.5",
+  "version": "4.0.0-alpha.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "curlconverter",
-      "version": "4.0.0-alpha.5",
+      "version": "4.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
         "cookie": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "curlconverter",
-  "version": "4.0.0-alpha.5",
+  "version": "4.0.0-alpha.6",
   "description": "convert curl commands to Python, JavaScript, Go, PHP and other languages",
   "homepage": "https://github.com/NickCarneiro/curlconverter",
   "author": {


### PR DESCRIPTION
that is the version of curl that we extracted the arguments from.

Also, bump curlconverter's version to release the fix for node-fetch